### PR TITLE
Bugfix: negative eigenvalues caused LinAlgErrors

### DIFF
--- a/deap/cma.py
+++ b/deap/cma.py
@@ -161,10 +161,11 @@ class Strategy(object):
         
         self.cond = self.diagD[indx[-1]]/self.diagD[indx[0]]
         
-        if not np.iscomplexobj(self.diagD):
-            self.diagD = np.abs(self.diagD[indx])
-        
-        self.diagD = self.diagD ** 0.5
+        if not numpy.iscomplexobj(self.diagD):
+            self.diagD = numpy.abs(self.diagD[indx]) ** 0.5
+        else:
+            self.diagD = self.diagD ** 0.5
+            
         self.B = self.B[:, indx]
         self.BD = self.B * self.diagD
 


### PR DESCRIPTION
In case we are not working with complex data types, calculating square roots of the diagonal can result in nan values (negative values in diagD). This will result in nan being generated as individuals and raising a LinAlgError.
