### PR TITLE
Sphinx-generated docs should have view-source option

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,8 @@ import deap
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones
 
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo',
-              'sphinx.ext.pngmath', 'sphinx.ext.intersphinx', 'sphinx.ext.extlinks'] 
+              'sphinx.ext.pngmath', 'sphinx.ext.intersphinx', 'sphinx.ext.extlinks',
+              'sphinx.ext.viewcode'] 
 
 try:
     import matplotlib


### PR DESCRIPTION
I find the docs for some functions(for instance the alpha parameter of cxBlend) difficult to understand, while the source is quite straightforward.  This commit adds the viewcode extension to the sphinx docs