### PR TITLE
Typo fixes.

### DIFF
--- a/doc/tutorials/advanced/constraints.rst
+++ b/doc/tutorials/advanced/constraints.rst
@@ -5,17 +5,17 @@ this tutorial, we present several ways of adding different types of constraints
 to your evolutions. This tutorial is based on the paper by Coello Coello
 [CoelloCoello2002]_.
 
-Penality Function
+Penalty Function
 -----------------
-Penality functions are the most basic way of handling constrains for individuals
-that cannot be evaluated or are forbiden for problem specific reasons, when
-falling in a given region. The penality function gives a fitness disadvantage to
+Penalty functions are the most basic way of handling constrains for individuals
+that cannot be evaluated or are forbidden for problem specific reasons, when
+falling in a given region. The penalty function gives a fitness disadvantage to
 these individuals based on the amount of constraint violation in the solution.
 For example, instead of evaluating an individual violating a constraint, one can
-assing a desired value to its fitness. The assigned value can be constant or
+assign a desired value to its fitness. The assigned value can be constant or
 increasing (decreasing for maximization) as the distance to a valid solution
 increases. The following figure shows the fitness function :math:`g(x)` (in green) and
-the penality function :math:`h(x)` (in red) of a one attribute individual, subject to the
+the penalty function :math:`h(x)` (in red) of a one attribute individual, subject to the
 constraint :math:`3 < x < 7`. The continuous line represent the fitness that is
 actually assigned to the individual :math:`f(x) = \left\lbrace \begin{array}{cl}g(x) &\mathrm{if}~3 < x < 7\\h(x)&\mathrm{otherwise}\end{array} \right.`.
 
@@ -27,11 +27,11 @@ The figure on the left uses a constant offset :math:`h(x) = \Delta` when a
 constraint is not respected. The center plot uses the euclidean distance in
 addition to the offset to create a bowl like fitness function :math:`h(x) =
 \Delta + \sqrt{(x-x_0)^2}`. Finally, the
-right plot uses a quadratic distance funtion to increase the attraction of the
+right plot uses a quadratic distance function to increase the attraction of the
 bowl :math:`h(x) = \Delta + (x-x_0)^2`, where :math:`x_0` is the approximate
 center of the valid zone.
 
-In DEAP, a penality function can be added to any evaluation function using  the
+In DEAP, a penalty function can be added to any evaluation function using  the
 :class:`~deap.tools.DeltaPenality` decorator provided in the :mod:`~deap.tools`
 module. ::
 
@@ -59,7 +59,7 @@ module. ::
 	toolbox.register("evaluate", evalFct)
 	toolbox.decorate("evaluate", tools.DeltaPenality(feasible, 7.0, distance))
 
-The penality decorator takes 2 mandatory arguments and an optional one. The
+The penalty decorator takes 2 mandatory arguments and an optional one. The
 first argument is a function returning the validity of an individual according
 to user defined constraints. The second argument is a constant value
 (:math:`\Delta`) returned when an individual is not valid. The optional argument

--- a/doc/tutorials/advanced/constraints.rst
+++ b/doc/tutorials/advanced/constraints.rst
@@ -47,7 +47,7 @@ module. ::
 	def feasible(individual):
 	    """Feasability function for the individual. Returns True if feasible False
 	    otherwise."""
-	    if 3 < individual[0] < 5:
+	    if 3 < individual[0] < 7:
 	        return True
 	    return False
 


### PR DESCRIPTION
Pretty obvious fixes.  Of greater concern is that the misspelling of 'penalty' ('penality') exists in class and function names and will be harder to fix. All other instances (eg in doco) can and should be fixed.