### PR TITLE
MetaCreator and MetaEphemeral for better pickling

### DIFF
--- a/deap/creator.py
+++ b/deap/creator.py
@@ -24,6 +24,7 @@ programming, evolution strategies, particle swarm optimizers, and many more.
 import array
 import copy
 import warnings
+import copy_reg
 
 class_replacers = {}
 """Some classes in Python's standard library as well as third party library
@@ -91,6 +92,46 @@ class _array(array.array):
         return (self.__class__, (list(self),), self.__dict__)
 class_replacers[array.array] = _array
 
+class MetaCreator(type):
+    def __new__(meta, name, base, dct):
+        return super(MetaCreator, meta).__new__(meta, name, (base,), dct)
+
+    def __init__(cls, name, base, dct):
+        # A DeprecationWarning is raised when the object inherits from the 
+        # class "object" which leave the option of passing arguments, but
+        # raise a warning stating that it will eventually stop permitting
+        # this option. Usually this happens when the base class does not
+        # override the __init__ method from object.
+        dict_inst = {}
+        dict_cls = {}
+        for obj_name, obj in dct.iteritems():
+            if isinstance(obj, type):
+                dict_inst[obj_name] = obj
+            else:
+                dict_cls[obj_name] = obj
+        def initType(self, *args, **kargs):
+            """Replace the __init__ function of the new type, in order to
+            add attributes that were defined with **kargs to the instance.
+            """
+            for obj_name, obj in dict_inst.iteritems():
+                setattr(self, obj_name, obj())
+            if base.__init__ is not object.__init__:
+                base.__init__(self, *args, **kargs)
+
+        cls.__init__ = initType
+        cls.reduce_args = (name, base, dct)
+        super(MetaCreator, cls).__init__(name, (base,), dict_cls)
+
+    def __reduce__(cls):
+        return (meta_create, cls.reduce_args)
+
+copy_reg.pickle(MetaCreator, MetaCreator.__reduce__)
+
+def meta_create(name, base, dct):
+    class_ = MetaCreator(name, base, dct)
+    globals()[name] = class_
+    return class_
+
 def create(name, base, **kargs):
     """Creates a new class named *name* inheriting from *base* in the
     :mod:`~deap.creator` module. The new class can have attributes defined by
@@ -138,32 +179,7 @@ def create(name, base, **kargs):
                       "creation of that class or rename it.".format(name),
                       RuntimeWarning)
 
-    dict_inst = {}
-    dict_cls = {}
-    for obj_name, obj in kargs.iteritems():
-        if isinstance(obj, type):
-            dict_inst[obj_name] = obj
-        else:
-            dict_cls[obj_name] = obj
-
     # Check if the base class has to be replaced
     if base in class_replacers:
         base = class_replacers[base]
-
-    # A DeprecationWarning is raised when the object inherits from the 
-    # class "object" which leave the option of passing arguments, but
-    # raise a warning stating that it will eventually stop permitting
-    # this option. Usually this happens when the base class does not
-    # override the __init__ method from object.
-    def initType(self, *args, **kargs):
-        """Replace the __init__ function of the new type, in order to
-        add attributes that were defined with **kargs to the instance.
-        """
-        for obj_name, obj in dict_inst.iteritems():
-            setattr(self, obj_name, obj())
-        if base.__init__ is not object.__init__:
-            base.__init__(self, *args, **kargs)
-
-    objtype = type(str(name), (base,), dict_cls)
-    objtype.__init__ = initType
-    globals()[name] = objtype
+    meta_create(name, base, kargs)

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -25,6 +25,7 @@ import copy_reg
 import random
 import re
 import sys
+import types
 import warnings
 
 from collections import defaultdict, deque
@@ -241,6 +242,12 @@ class MetaEphemeral(type):
     def __new__(meta, name, func, ret=__type__, id_=None):
         if id_ in MetaEphemeral.cache:
             return MetaEphemeral.cache[id_]
+
+        if isinstance(func, types.LambdaType) and func.__name__ == '<lambda>':
+            warnings.warn("Ephemeral {name} function cannot be "
+                          "pickled because its generating function "
+                          "is a lambda function. Use functools.partial "
+                          "instead.".format(name=name), RuntimeWarning)
 
         def __init__(self):
             self.value = func()

--- a/deap/tests/test_pickle.py
+++ b/deap/tests/test_pickle.py
@@ -5,6 +5,7 @@ import array
 import pickle
 import operator
 import platform
+import functools
 
 import numpy
 
@@ -99,7 +100,7 @@ class Pickling(unittest.TestCase):
     def test_pickle_tree_ephemeral(self):
         pset = gp.PrimitiveSetTyped("MAIN", [], int, "IN")
         pset.addPrimitive(operator.add, [int, int], int)
-        pset.addEphemeralConstant("E1", lambda: 2, int)
+        pset.addEphemeralConstant("E1", functools.partial(int, 2), int)
 
         expr = gp.genFull(pset, min_=1, max_=1)
         ind = creator.IndTree(expr)

--- a/examples/ga/onemax_mp.py
+++ b/examples/ga/onemax_mp.py
@@ -30,29 +30,28 @@ from deap import base
 from deap import creator
 from deap import tools
 
-
-creator.create("FitnessMax", base.Fitness, weights=(1.0,))
-creator.create("Individual", array.array, typecode='b', fitness=creator.FitnessMax)
-
-toolbox = base.Toolbox()
-
-# Attribute generator
-toolbox.register("attr_bool", random.randint, 0, 1)
-
-# Structure initializers
-toolbox.register("individual", tools.initRepeat, creator.Individual, toolbox.attr_bool, 100)
-toolbox.register("population", tools.initRepeat, list, toolbox.individual)
-
 def evalOneMax(individual):
     return sum(individual),
 
-toolbox.register("evaluate", evalOneMax)
-toolbox.register("mate", tools.cxTwoPoint)
-toolbox.register("mutate", tools.mutFlipBit, indpb=0.05)
-toolbox.register("select", tools.selTournament, tournsize=3)
+def main(seed):
+    random.seed(seed)
 
-if __name__ == "__main__":
-    random.seed(64)
+    creator.create("FitnessMax", base.Fitness, weights=(1.0,))
+    creator.create("Individual", array.array, typecode='b', fitness=creator.FitnessMax)
+
+    toolbox = base.Toolbox()
+
+    # Attribute generator
+    toolbox.register("attr_bool", random.randint, 0, 1)
+
+    # Structure initializers
+    toolbox.register("individual", tools.initRepeat, creator.Individual, toolbox.attr_bool, 100)
+    toolbox.register("population", tools.initRepeat, list, toolbox.individual)
+
+    toolbox.register("evaluate", evalOneMax)
+    toolbox.register("mate", tools.cxTwoPoint)
+    toolbox.register("mutate", tools.mutFlipBit, indpb=0.05)
+    toolbox.register("select", tools.selTournament, tournsize=3)
     
     # Process Pool of 4 workers
     pool = multiprocessing.Pool(processes=4)
@@ -70,3 +69,6 @@ if __name__ == "__main__":
                         stats=stats, halloffame=hof)
 
     pool.close()
+
+if __name__ == "__main__":
+    main(64)

--- a/examples/gp/adf_symbreg.py
+++ b/examples/gp/adf_symbreg.py
@@ -19,6 +19,8 @@ import math
 
 import numpy
 
+from functools import partial
+
 from deap import base
 from deap import creator
 from deap import gp
@@ -69,7 +71,7 @@ pset.addPrimitive(protectedDiv, 2)
 pset.addPrimitive(operator.neg, 1)
 pset.addPrimitive(math.cos, 1)
 pset.addPrimitive(math.sin, 1)
-pset.addEphemeralConstant("rand101", lambda: random.randint(-1, 1))
+pset.addEphemeralConstant("rand101", partial(random.randint, -1, 1))
 pset.addADF(adfset0)
 pset.addADF(adfset1)
 pset.addADF(adfset2)

--- a/examples/gp/spambase.py
+++ b/examples/gp/spambase.py
@@ -20,6 +20,8 @@ import itertools
 
 import numpy
 
+from functools import partial
+
 from deap import algorithms
 from deap import base
 from deap import creator
@@ -64,7 +66,7 @@ pset.addPrimitive(operator.eq, [float, float], bool)
 pset.addPrimitive(if_then_else, [bool, float, float], float)
 
 # terminals
-pset.addEphemeralConstant("rand100", lambda: random.random() * 100, float)
+pset.addEphemeralConstant("rand100", partial(random.uniform, 0, 100), float)
 pset.addTerminal(False, bool)
 pset.addTerminal(True, bool)
 

--- a/examples/gp/symbreg.py
+++ b/examples/gp/symbreg.py
@@ -19,6 +19,8 @@ import random
 
 import numpy
 
+from functools import partial
+
 from deap import algorithms
 from deap import base
 from deap import creator
@@ -40,7 +42,7 @@ pset.addPrimitive(protectedDiv, 2)
 pset.addPrimitive(operator.neg, 1)
 pset.addPrimitive(math.cos, 1)
 pset.addPrimitive(math.sin, 1)
-pset.addEphemeralConstant("rand101", lambda: random.randint(-1,1))
+pset.addEphemeralConstant("rand101", partial(random.randint, -1, 1))
 pset.renameArguments(ARG0='x')
 
 creator.create("FitnessMin", base.Fitness, weights=(-1.0,))

--- a/examples/gp/symbreg_numpy.py
+++ b/examples/gp/symbreg_numpy.py
@@ -19,6 +19,8 @@ import random
 
 import numpy
 
+from functools import partial
+
 from deap import algorithms
 from deap import base
 from deap import creator
@@ -44,7 +46,7 @@ pset.addPrimitive(protectedDiv, 2)
 pset.addPrimitive(numpy.negative, 1, name="vneg")
 pset.addPrimitive(numpy.cos, 1, name="vcos")
 pset.addPrimitive(numpy.sin, 1, name="vsin")
-pset.addEphemeralConstant("rand101", lambda: random.randint(-1,1))
+pset.addEphemeralConstant("rand101", partial(random.randint, -1, 1))
 pset.renameArguments(ARG0='x')
 
 creator.create("FitnessMin", base.Fitness, weights=(-1.0,))


### PR DESCRIPTION
This pull-request solves two problems we have in DEAP using Python metaclass.
1. Calling `creator.create` outside the global scope would prevent instances of the created classes to be pickled. This complicated things when trying to communicate the objects in a context of distributed computation.
2. Genetic programming (GP) ephemeral constant could not be pickled unless the `PrimitiveSet` is instantiated in the main module global scope. The reason is that when adding ephemeral constant to a PrimitiveSet, a new class is generated with `type` and it is added to the `gp` module scope. This is hackish, but allowed to a certain extend the pickling of `PrimitiveTree` that would contain `Ephemerals`.

The solutions to each problem are similar and are inspired by [Python issue 7689 Pickling of classes with a metaclass and copy_reg](http://bugs.python.org/issue7689). The idea is to replace calls to `type` by our own metaclass and to register in `copy_reg` how classes were created using this metaclass. This means that when we pickle an instance of a class created dynamically, we also pickled how this class can be built from scratch.

This pull request introduces two metaclasses, one for each problem.
1. `creator.MetaCreator`
2. `gp.MetaEphemeral`

The idea should be exploited further. For example, we could have a `MetaFitness` that would make sure the `weights` attribute is set when creating the class. The behavior of the `Fitness` class could also be adjusted, so for example the evaluation function would not have to return a tuple for single objective problem.

N.B.: This is a repost of PR #58. I have closed the former as it was not in a proper feature branch.
