### PR TITLE
Fix pip install command

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -31,7 +31,7 @@ version. ::
 
 or ::
 
-   pip deap
+   pip install deap
 
 If you wish to build from sources, download_ or clone_ the repository and type::
 


### PR DESCRIPTION
`pip deap` doesn't work, but `pip install deap` does