### PR TITLE
Fixed reading of UTF-8 files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ try:
     from pypandoc import convert
 except ImportError:
     warnings.append("warning: pypandoc module not found, could not convert Markdown to RST")
-    read_md = lambda f: open(f, 'r').read()
+    import codecs
+    read_md = lambda f: codecs.open(f, 'r', 'utf-8').read()
 else:
     read_md = lambda f: convert(f, 'rst')
 


### PR DESCRIPTION
I've just tried to perform `pip install deap` on an ArchLinux system using Anaconda 3, and it crashed saying:

    warning: pypandoc module not found, could not convert Markdown to RST
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-5xgtngz9/deap/setup.py", line 22, in <module>
        long_description=read_md('README.md'),
      File "/tmp/pip-build-5xgtngz9/deap/setup.py", line 13, in <lambda>
        read_md = lambda f: open(f, 'r').read()
      File "/root/anaconda3/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 4945: ordinal not in range(128)

The same occured when trying the `master` version of the git repository.

Here's a fix provided. Should work on Python 2.7 and Python 3.2+.