### PR TITLE
dltz5 and 6: fix calculation of first objective

### DIFF
--- a/deap/benchmarks/__init__.py
+++ b/deap/benchmarks/__init__.py
@@ -586,7 +586,9 @@ def dtlz5(ind, n_objs):
     gval = g(ind[n_objs-1:])
     
     theta = lambda x: pi / (4.0 * (1 + gval)) * (1 + 2 * gval * x)
-    fit = [(1 + gval) * cos(pi / 2.0 * ind[0]) * reduce(lambda x,y: x*y, [cos(theta(a)) for a in ind[1:]])]
+
+    fit = [(1 + gval) * cos(pi / 2.0 * ind[0]) *
+           reduce(lambda x,y: x*y, [cos(theta(a)) for a in ind[1:n_objs-1]]) if n_objs > 2 else 1]
            
     for m in reversed(range(1, n_objs)):
         if m == 1:
@@ -604,9 +606,9 @@ def dtlz6(ind, n_objs):
     """
     gval = sum([a**0.1 for a in ind[n_objs-1:]])
     theta = lambda x: pi / (4.0 * (1 + gval)) * (1 + 2 * gval * x)
-    
+
     fit = [(1 + gval) * cos(pi / 2.0 * ind[0]) *
-           reduce(lambda x,y: x*y, [cos(theta(a)) for a in ind[1:]])]
+           reduce(lambda x,y: x*y, [cos(theta(a)) for a in ind[1:n_objs-1]]) if n_objs > 2 else 1]
 
     for m in reversed(range(1, n_objs)):
         if m == 1:


### PR DESCRIPTION
Reference implementations: [Shark](http://image.diku.dk/shark/doxygen_pages/html/_d_t_l_z6_8h_source.html) and [jMetal](https://github.com/jMetal/jMetal/blob/master/jmetal-problem/src/main/java/org/uma/jmetal/problem/multiobjective/dtlz/DTLZ6.java).

The paper is not very helpful in this case, and as these two come to the same result, I consider their calculation to be right.