### PR TITLE
STGP: Primitive/Terminal dicts are identical for bool and int

### DIFF
--- a/deap/gp.py
+++ b/deap/gp.py
@@ -315,7 +315,7 @@ class PrimitiveSetTyped(object):
             dict_ = self.terminals
 
         for type_ in dict_:
-            if issubclass(prim.ret, type_):
+            if issubclass(prim.ret, type_) and prim.ret is not bool:
                 dict_[type_].append(prim)
 
     def addPrimitive(self, primitive, in_types, ret_type, name=None):

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -604,9 +604,9 @@ def generate(pset, min_, max_, condition, type_=None):
             try:
                 term = random.choice(pset.terminals[type_])
                 if type_ is bool:
-                    print("Terminal bool", type_, isinstance(type_, bool))
+                    print("Terminal bool", type_, isinstance(type_, bool), term)
                 elif type_ is int:
-                    print("Terminal int", type_, isinstance(type_, bool))
+                    print("Terminal int", type_, isinstance(type_, bool), term)
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\
@@ -619,9 +619,9 @@ def generate(pset, min_, max_, condition, type_=None):
             try:
                 prim = random.choice(pset.primitives[type_])
                 if type_ is bool:
-                    print("Primative bool", type_, isinstance(type_, bool))
+                    print("Primative bool", type_, isinstance(type_, bool), prim)
                 elif type_ is int:
-                    print("Primative int", type_, isinstance(type_, bool))
+                    print("Primative int", type_, isinstance(type_, bool), prim)
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -296,7 +296,7 @@ class PrimitiveSetTyped(object):
             if not ret_type in dict_:
                 new_list = []
                 for type_, list_ in dict_.items():
-                    if issubclass(type_, ret_type) and type_ is not bool:
+                    if (type_, ret_type) != (bool, int) and issubclass(type_, ret_type):
                         for item in list_:
                             if not item in new_list:
                                 new_list.append(item)
@@ -315,7 +315,7 @@ class PrimitiveSetTyped(object):
             dict_ = self.terminals
 
         for type_ in dict_:
-            if issubclass(prim.ret, type_):
+            if (prim.ret, type_) != (bool, int) and issubclass(prim.ret, type_):
                 dict_[type_].append(prim)
 
     def addPrimitive(self, primitive, in_types, ret_type, name=None):

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -604,7 +604,7 @@ def generate(pset, min_, max_, condition, type_=None):
             try:
                 term = random.choice(pset.terminals[type_])
                 if type_ is int or type_ is bool:
-                    print("Terminal", type(type_), isinstance(type_, bool))
+                    print("Terminal", type_, isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\
@@ -617,7 +617,7 @@ def generate(pset, min_, max_, condition, type_=None):
             try:
                 prim = random.choice(pset.primitives[type_])
                 if type_ is int or type_ is bool:
-                    print("Primative", type(type_), isinstance(type_, bool))
+                    print("Primative", type_, isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -603,7 +603,7 @@ def generate(pset, min_, max_, condition, type_=None):
         if condition(height, depth):
             try:
                 term = random.choice(pset.terminals[type_])
-                if type(type_) is int or type(type_) is bool:
+                if type_ is int or type_ is bool:
                     print("Terminal", type(type_), isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
@@ -616,7 +616,7 @@ def generate(pset, min_, max_, condition, type_=None):
         else:
             try:
                 prim = random.choice(pset.primitives[type_])
-                if type(type_) is int or type(type_) is bool:
+                if type_ is int or type_ is bool:
                     print("Primative", type(type_), isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -315,7 +315,7 @@ class PrimitiveSetTyped(object):
             dict_ = self.terminals
 
         for type_ in dict_:
-            if issubclass(prim.ret, type_) and prim.ret is not bool type_ is not int:
+            if issubclass(prim.ret, type_) and prim.ret is not bool and type_ is not int:
                 dict_[type_].append(prim)
 
     def addPrimitive(self, primitive, in_types, ret_type, name=None):

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -604,9 +604,9 @@ def generate(pset, min_, max_, condition, type_=None):
             try:
                 term = random.choice(pset.terminals[type_])
                 if type_ is bool:
-                    print("Terminal bool", type_.__name__, isinstance(type_, bool))
+                    print("Terminal bool", type_, isinstance(type_, bool))
                 elif type_ is int:
-                    print("Terminal int", type_.__name__, isinstance(type_, bool))
+                    print("Terminal int", type_, isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -296,7 +296,7 @@ class PrimitiveSetTyped(object):
             if not ret_type in dict_:
                 new_list = []
                 for type_, list_ in dict_.items():
-                    if issubclass(type_, ret_type):
+                    if issubclass(type_, ret_type) and type_ is not bool:
                         for item in list_:
                             if not item in new_list:
                                 new_list.append(item)

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -603,8 +603,10 @@ def generate(pset, min_, max_, condition, type_=None):
         if condition(height, depth):
             try:
                 term = random.choice(pset.terminals[type_])
-                if type_ is int or type_ is bool:
-                    print("Terminal", type_, isinstance(type_, bool))
+                if type_ is int:
+                    print("Terminal int", type_, isinstance(type_, bool))
+                elif type_ is bool:
+                    print("Terminal bool", type_, isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\
@@ -616,8 +618,10 @@ def generate(pset, min_, max_, condition, type_=None):
         else:
             try:
                 prim = random.choice(pset.primitives[type_])
-                if type_ is int or type_ is bool:
-                    print("Primative", type_, isinstance(type_, bool))
+                if type_ is int:
+                    print("Primative int", type_, isinstance(type_, bool))
+                elif type_ is bool:
+                    print("Primative bool", type_, isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -603,10 +603,6 @@ def generate(pset, min_, max_, condition, type_=None):
         if condition(height, depth):
             try:
                 term = random.choice(pset.terminals[type_])
-                if type_ is bool:
-                    print("Terminal bool", type_, isinstance(type_, bool), term)
-                elif type_ is int:
-                    print("Terminal int", type_, isinstance(type_, bool), term)
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\
@@ -618,10 +614,6 @@ def generate(pset, min_, max_, condition, type_=None):
         else:
             try:
                 prim = random.choice(pset.primitives[type_])
-                if type_ is bool:
-                    print("Primative bool", type_, isinstance(type_, bool), prim)
-                elif type_ is int:
-                    print("Primative int", type_, isinstance(type_, bool), prim)
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -315,7 +315,7 @@ class PrimitiveSetTyped(object):
             dict_ = self.terminals
 
         for type_ in dict_:
-            if issubclass(prim.ret, type_) and prim.ret is not bool:
+            if issubclass(prim.ret, type_) and prim.ret is not bool type_ is not int:
                 dict_[type_].append(prim)
 
     def addPrimitive(self, primitive, in_types, ret_type, name=None):

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -315,7 +315,8 @@ class PrimitiveSetTyped(object):
             dict_ = self.terminals
 
         for type_ in dict_:
-            if issubclass(prim.ret, type_) and prim.ret is not bool and type_ is not int:
+            if issubclass(prim.ret, type_):
+                print(prim.ret, type_)
                 dict_[type_].append(prim)
 
     def addPrimitive(self, primitive, in_types, ret_type, name=None):

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -603,10 +603,10 @@ def generate(pset, min_, max_, condition, type_=None):
         if condition(height, depth):
             try:
                 term = random.choice(pset.terminals[type_])
-                if type_ is int:
-                    print("Terminal int", type_, isinstance(type_, bool))
-                elif type_ is bool:
-                    print("Terminal bool", type_, isinstance(type_, bool))
+                if type_ is bool:
+                    print("Terminal bool", type_.__name__, isinstance(type_, bool))
+                elif type_ is int:
+                    print("Terminal int", type_.__name__, isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\
@@ -618,10 +618,10 @@ def generate(pset, min_, max_, condition, type_=None):
         else:
             try:
                 prim = random.choice(pset.primitives[type_])
-                if type_ is int:
-                    print("Primative int", type_, isinstance(type_, bool))
-                elif type_ is bool:
+                if type_ is bool:
                     print("Primative bool", type_, isinstance(type_, bool))
+                elif type_ is int:
+                    print("Primative int", type_, isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -315,7 +315,7 @@ class PrimitiveSetTyped(object):
             dict_ = self.terminals
 
         for type_ in dict_:
-            if issubclass(prim.ret, type_):
+            if issubclass(prim.ret, type_) and type_ is not bool:
                 dict_[type_].append(prim)
 
     def addPrimitive(self, primitive, in_types, ret_type, name=None):

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -316,7 +316,6 @@ class PrimitiveSetTyped(object):
 
         for type_ in dict_:
             if issubclass(prim.ret, type_):
-                print(prim.ret, type_)
                 dict_[type_].append(prim)
 
     def addPrimitive(self, primitive, in_types, ret_type, name=None):

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -315,7 +315,7 @@ class PrimitiveSetTyped(object):
             dict_ = self.terminals
 
         for type_ in dict_:
-            if issubclass(prim.ret, type_) and type_ is not bool:
+            if issubclass(prim.ret, type_):
                 dict_[type_].append(prim)
 
     def addPrimitive(self, primitive, in_types, ret_type, name=None):

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -603,6 +603,8 @@ def generate(pset, min_, max_, condition, type_=None):
         if condition(height, depth):
             try:
                 term = random.choice(pset.terminals[type_])
+                if type(type_) is int or type(type_) is bool:
+                    print("Terminal", type(type_), isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\
@@ -614,6 +616,8 @@ def generate(pset, min_, max_, condition, type_=None):
         else:
             try:
                 prim = random.choice(pset.primitives[type_])
+                if type(type_) is int or type(type_) is bool:
+                    print("Primative", type(type_), isinstance(type_, bool))
             except IndexError:
                 _, _, traceback = sys.exc_info()
                 raise IndexError, "The gp.generate function tried to add "\


### PR DESCRIPTION
Since bool is a subclass of int, the primitive/terminal dicts for int and bool were identical resulting in the trees not forming correctly

See https://groups.google.com/forum/#!topic/deap-users/ojY-YwKOPPA