### PR TITLE
Include reference to paper in cma.Strategy and cma.StrategyOnePlusLambda

### DIFF
--- a/deap/cma.py
+++ b/deap/cma.py
@@ -30,7 +30,7 @@ import tools
 class Strategy(object):
     """
     A strategy that will keep track of the basic parameters of the CMA-ES
-    algorithm.
+    algorithm ([Hansen2001]_).
 
     :param centroid: An iterable object that indicates where to start the
                      evolution.
@@ -76,6 +76,9 @@ class Strategy(object):
     |                | mueff) / ((N + 2)^2 +     | update.                    |
     |                | mueff)``                  |                            |
     +----------------+---------------------------+----------------------------+
+
+    .. [Hansen2001] Hansen and Ostermeier, 2001. Completely Derandomized
+       Self-Adaptation in Evolution Strategies. *Evolutionary Computation*
 
     """
     def __init__(self, centroid, sigma, **kargs):
@@ -204,7 +207,7 @@ class Strategy(object):
 
 class StrategyOnePlusLambda(object):
     """
-    A CMA-ES strategy that uses the :math:`1 + \lambda` paradigm.
+    A CMA-ES strategy that uses the :math:`1 + \lambda` paradigm ([Igel2007]_).
 
     :param parent: An iterable object that indicates where to start the
                    evolution. The parent requires a fitness attribute.
@@ -235,6 +238,10 @@ class StrategyOnePlusLambda(object):
     +----------------+---------------------------+----------------------------+
     | ``pthresh``    | ``0.44``                  | Threshold success rate.    |
     +----------------+---------------------------+----------------------------+
+
+    .. [Igel2007] Igel, Hansen, Roth, 2007. Covariance matrix adaptation for
+    multi-objective optimization. *Evolutionary Computation* Spring;15(1):1-28
+
     """
     def __init__(self, parent, sigma, **kargs):
         self.parent = parent


### PR DESCRIPTION
The reference to the paper where the implementation of CMA is detailed apears in the [cma-es example](https://deap.readthedocs.org/en/master/examples/cmaes.html), but not in the class docstring. Thus, when looking at the [cma strategies api documentation](https://deap.readthedocs.org/en/master/api/algo.html#module-deap.cma), the relevant reference cannot be found.

I added the citation in the docstrings  of the cma strategy classes, so that this would fix #132.