### PR TITLE
Fixes error in `offspring[::2]` in Python 3

### DIFF
--- a/doc/code/tutorials/part_1/1_where_to_start.py
+++ b/doc/code/tutorials/part_1/1_where_to_start.py
@@ -38,7 +38,7 @@ def main():
         # Select the next generation individuals
         offspring = toolbox.select(pop, len(pop))
         # Clone the selected individuals
-        offspring = map(toolbox.clone, offspring)
+        offspring = list(map(toolbox.clone, offspring))
 
         # Apply crossover and mutation on the offspring
         for child1, child2 in zip(offspring[::2], offspring[1::2]):


### PR DESCRIPTION
In Python 3, the example code fails at `offspring[::2], offspring[1::2]` with:

```
TypeError: 'map' object is not subscriptable
```
