### PR TITLE
Fix a Error , A Error about create indicidual in selection functions

### DIFF
--- a/deap/tools/selection.py
+++ b/deap/tools/selection.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import random
+import copy
 
 from functools import partial
 from operator import attrgetter
@@ -91,7 +92,9 @@ def selRoulette(individuals, k):
         for ind in s_inds:
             sum_ += ind.fitness.values[0]
             if sum_ > u:
-                chosen.append(ind)
+                chosen.append(copy.deepcopy(ind))  # others like this should be changed too , 
+                # if you have anything want to say ,please tell me : ss1992@126.com ,thank you
+                # forgive my poor english , i'm chinese...
                 break
     
     return chosen

--- a/deap/tools/selection.py
+++ b/deap/tools/selection.py
@@ -92,9 +92,7 @@ def selRoulette(individuals, k):
         for ind in s_inds:
             sum_ += ind.fitness.values[0]
             if sum_ > u:
-                chosen.append(copy.deepcopy(ind))  # others like this should be changed too , 
-                # if you have anything want to say ,please tell me : ss1992@126.com ,thank you
-                # forgive my poor english , i'm chinese...
+                chosen.append(copy.deepcopy(ind))  # other selection-functions like this should be changed too , 
                 break
     
     return chosen


### PR DESCRIPTION
我是中国人。。
就写个中文说明吧。。
哈哈哈
问题就是：在选择函数中如果不用深度拷贝添加选择的个体，会导致在新种群中出现多个名字不同但实体相同的个体，循环多次会导致所有个体都一样了
----
Translate the above sentence :

The question is: in the selection functions , when add an individual should use "deep copy" , if not use "deep copy" will cause a error : in the new population one individual appears servel times but actually all of them is the same one , and after circle many times, all the individuals in a population become a same indicidual

this patch just fixed one selection function, other selection functions should be fixed like this too.

by the way , i use deap 1.0.2 and python3.5.2


if you not accept this change , please tell me why. thank you !   (forgive my poor english)  ╮(╯▽╰)╭
my email: ss1992@126.com  or  heroliss@hotmail.com