### PR TITLE
Fixed bin2float behavior and added test suite for benchamarks.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 language: python
+branches:
+  only:
+    - master
+    - develop
+        
 matrix:
   include:
     - python: "2.7"
@@ -18,6 +23,7 @@ addons:
 install:
   - python setup.py install
   - pip install $NUMPY
+  - pip install future
   - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '3' ]]; then 2to3 --output-dir=py3k/deap -W -n deap; fi
 # command to run tests
 script:

--- a/deap/algorithms.py
+++ b/deap/algorithms.py
@@ -46,17 +46,17 @@ def varAnd(population, toolbox, cxpb, mutpb):
 
     The variation goes as follow. First, the parental population
     :math:`P_\mathrm{p}` is duplicated using the :meth:`toolbox.clone` method
-    and the result is put into the offspring population :math:`P_\mathrm{o}`.
-    A first loop over :math:`P_\mathrm{o}` is executed to mate pairs of consecutive
-    individuals. According to the crossover probability *cxpb*, the
+    and the result is put into the offspring population :math:`P_\mathrm{o}`.  A
+    first loop over :math:`P_\mathrm{o}` is executed to mate pairs of
+    consecutive individuals. According to the crossover probability *cxpb*, the
     individuals :math:`\mathbf{x}_i` and :math:`\mathbf{x}_{i+1}` are mated
     using the :meth:`toolbox.mate` method. The resulting children
     :math:`\mathbf{y}_i` and :math:`\mathbf{y}_{i+1}` replace their respective
     parents in :math:`P_\mathrm{o}`. A second loop over the resulting
     :math:`P_\mathrm{o}` is executed to mutate every individual with a
     probability *mutpb*. When an individual is mutated it replaces its not
-    mutated version in :math:`P_\mathrm{o}`. The resulting
-    :math:`P_\mathrm{o}` is returned.
+    mutated version in :math:`P_\mathrm{o}`. The resulting :math:`P_\mathrm{o}`
+    is returned.
 
     This variation is named *And* beceause of its propention to apply both
     crossover and mutation on the individuals. Note that both operators are
@@ -70,7 +70,8 @@ def varAnd(population, toolbox, cxpb, mutpb):
     # Apply crossover and mutation on the offspring
     for i in range(1, len(offspring), 2):
         if random.random() < cxpb:
-            offspring[i - 1], offspring[i] = toolbox.mate(offspring[i - 1], offspring[i])
+            offspring[i - 1], offspring[i] = toolbox.mate(offspring[i - 1],
+                                                          offspring[i])
             del offspring[i - 1].fitness.values, offspring[i].fitness.values
 
     for i in range(len(offspring)):
@@ -223,8 +224,9 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
     shall be in :math:`[0, 1]`, the reproduction probability is
     1 - *cxpb* - *mutpb*.
     """
-    assert (cxpb + mutpb) <= 1.0, ("The sum of the crossover and mutation "
-                                   "probabilities must be smaller or equal to 1.0.")
+    assert (cxpb + mutpb) <= 1.0, (
+        "The sum of the crossover and mutation probabilities must be smaller "
+        "or equal to 1.0.")
 
     offspring = []
     for _ in xrange(lambda_):
@@ -382,9 +384,9 @@ def eaMuCommaLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen,
 
     .. note::
 
-        Care must be taken when the lambda:mu ratio is 1 to 1 as a non-stochastic
-        selection will result in no selection at all as
-        the operator selects *lambda* individuals from a pool of *mu*.
+        Care must be taken when the lambda:mu ratio is 1 to 1 as a
+        non-stochastic selection will result in no selection at all as the
+        operator selects *lambda* individuals from a pool of *mu*.
 
 
     This function expects :meth:`toolbox.mate`, :meth:`toolbox.mutate`,

--- a/deap/base.py
+++ b/deap/base.py
@@ -187,9 +187,10 @@ class Fitness(object):
             _, _, traceback = sys.exc_info()
             raise TypeError, ("Both weights and assigned values must be a "
                               "sequence of numbers when assigning to values of "
-                              "%r. Currently assigning value(s) %r of %r to a fitness with "
-                              "weights %s."
-                              % (self.__class__, values, type(values), self.weights)), traceback
+                              "%r. Currently assigning value(s) %r of %r to a "
+                              "fitness with weights %s."
+                              % (self.__class__, values, type(values),
+                                 self.weights)), traceback
 
     def delValues(self):
         self.wvalues = ()

--- a/deap/benchmarks/binary.py
+++ b/deap/benchmarks/binary.py
@@ -13,8 +13,6 @@
 #    You should have received a copy of the GNU Lesser General Public
 #    License along with DEAP. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-import math
 
 def bin2float(min_, max_, nbits):
     """Convert a binary array into an array of float where each
@@ -27,13 +25,9 @@ def bin2float(min_, max_, nbits):
     """
     def wrap(function):
         def wrapped_function(individual, *args, **kargs):
-            nelem = len(individual)/nbits
-            if nelem.is_integer():
-                nelem = int(nelem)
-            else:
-                raise ValueError(
-                    "Got an array of size %s to divide into %s parts" % (
-                        nbits, nelem))
+            # // Forces the division behavior to be the same in python2 and
+            # python3; user must take care to make nelem an integer.
+            nelem = len(individual)//nbits
             decoded = [0] * nelem
             for i in xrange(nelem):
                 gene = int("".join(map(str,
@@ -45,6 +39,7 @@ def bin2float(min_, max_, nbits):
         return wrapped_function
     return wrap
 
+
 def trap(individual):
     u = sum(individual)
     k = len(individual)
@@ -53,6 +48,7 @@ def trap(individual):
     else:
         return k - 1 - u
 
+
 def inv_trap(individual):
     u = sum(individual)
     k = len(individual)
@@ -60,6 +56,7 @@ def inv_trap(individual):
         return k
     else:
         return u - 1
+
 
 def chuang_f1(individual):
     """Binary deceptive function from : Multivariate Multi-Model Approach for
@@ -70,12 +67,13 @@ def chuang_f1(individual):
     """
     total = 0
     if individual[-1] == 0:
-        for i in xrange(0,len(individual)-1,4):
+        for i in xrange(0, len(individual)-1, 4):
             total += inv_trap(individual[i:i+4])
     else:
-        for i in xrange(0,len(individual)-1,4):
+        for i in xrange(0, len(individual)-1, 4):
             total += trap(individual[i:i+4])
     return total,
+
 
 def chuang_f2(individual):
     """Binary deceptive function from : Multivariate Multi-Model Approach for
@@ -86,18 +84,19 @@ def chuang_f2(individual):
     """
     total = 0
     if individual[-2] == 0 and individual[-1] == 0:
-        for i in xrange(0,len(individual)-2,8):
+        for i in xrange(0, len(individual)-2, 8):
             total += inv_trap(individual[i:i+4]) + inv_trap(individual[i+4:i+8])
     elif individual[-2] == 0 and individual[-1] == 1:
-        for i in xrange(0,len(individual)-2,8):
+        for i in xrange(0, len(individual)-2, 8):
             total += inv_trap(individual[i:i+4]) + trap(individual[i+4:i+8])
     elif individual[-2] == 1 and individual[-1] == 0:
-        for i in xrange(0,len(individual)-2,8):
+        for i in xrange(0, len(individual)-2, 8):
             total += trap(individual[i:i+4]) + inv_trap(individual[i+4:i+8])
     else:
-        for i in xrange(0,len(individual)-2,8):
+        for i in xrange(0, len(individual)-2, 8):
             total += trap(individual[i:i+4]) + trap(individual[i+4:i+8])
     return total,
+
 
 def chuang_f3(individual):
     """Binary deceptive function from : Multivariate Multi-Model Approach for
@@ -108,26 +107,28 @@ def chuang_f3(individual):
     """
     total = 0
     if individual[-1] == 0:
-        for i in xrange(0,len(individual)-1,4):
+        for i in xrange(0, len(individual)-1, 4):
             total += inv_trap(individual[i:i+4])
     else:
-        for i in xrange(2,len(individual)-3,4):
+        for i in xrange(2, len(individual)-3, 4):
             total += inv_trap(individual[i:i+4])
         total += trap(individual[-2:]+individual[:2])
     return total,
+
 
 # Royal Road Functions
 def royal_road1(individual, order):
     """Royal Road Function R1 as presented by Melanie Mitchell in :
     "An introduction to Genetic Algorithms".
     """
-    nelem = len(individual) / order
+    nelem = len(individual) // order
     max_value = int(2**order - 1)
     total = 0
     for i in xrange(nelem):
         value = int("".join(map(str, individual[i*order:i*order+order])), 2)
         total += int(order) * int(value/max_value)
     return total,
+
 
 def royal_road2(individual, order):
     """Royal Road Function R2 as presented by Melanie Mitchell in :
@@ -139,4 +140,3 @@ def royal_road2(individual, order):
         total += royal_road1(norder, individual)[0]
         norder *= 2
     return total,
-

--- a/deap/benchmarks/binary.py
+++ b/deap/benchmarks/binary.py
@@ -14,6 +14,7 @@
 #    License along with DEAP. If not, see <http://www.gnu.org/licenses/>.
 
 import math
+from __future__ import division
 
 def bin2float(min_, max_, nbits):
     """Convert a binary array into an array of float where each
@@ -27,9 +28,16 @@ def bin2float(min_, max_, nbits):
     def wrap(function):
         def wrapped_function(individual, *args, **kargs):
             nelem = len(individual)/nbits
+            if nelem.is_integer():
+                nelem = int(nelem)
+            else:
+                raise ValueError(
+                    "Got an array of size %s to divide into %s parts" % (
+                        nbits, nelem))
             decoded = [0] * nelem
             for i in xrange(nelem):
-                gene = int("".join(map(str, individual[i*nbits:i*nbits+nbits])), 2)
+                gene = int("".join(map(str,
+                                       individual[i*nbits:i*nbits+nbits])), 2)
                 div = 2**nbits - 1
                 temp = float(gene)/float(div)
                 decoded[i] = min_ + (temp * (max_ - min_))
@@ -56,10 +64,10 @@ def inv_trap(individual):
 def chuang_f1(individual):
     """Binary deceptive function from : Multivariate Multi-Model Approach for
     Globally Multimodal Problems by Chung-Yao Chuang and Wen-Lian Hsu.
-    
+
     The function takes individual of 40+1 dimensions and has two global optima
     in [1,1,...,1] and [0,0,...,0].
-    """    
+    """
     total = 0
     if individual[-1] == 0:
         for i in xrange(0,len(individual)-1,4):
@@ -72,10 +80,10 @@ def chuang_f1(individual):
 def chuang_f2(individual):
     """Binary deceptive function from : Multivariate Multi-Model Approach for
     Globally Multimodal Problems by Chung-Yao Chuang and Wen-Lian Hsu.
-    
+
     The function takes individual of 40+1 dimensions and has four global optima
-    in [1,1,...,0,0], [0,0,...,1,1], [1,1,...,1] and [0,0,...,0].    
-    """    
+    in [1,1,...,0,0], [0,0,...,1,1], [1,1,...,1] and [0,0,...,0].
+    """
     total = 0
     if individual[-2] == 0 and individual[-1] == 0:
         for i in xrange(0,len(individual)-2,8):
@@ -110,7 +118,7 @@ def chuang_f3(individual):
 
 # Royal Road Functions
 def royal_road1(individual, order):
-    """Royal Road Function R1 as presented by Melanie Mitchell in : 
+    """Royal Road Function R1 as presented by Melanie Mitchell in :
     "An introduction to Genetic Algorithms".
     """
     nelem = len(individual) / order
@@ -122,7 +130,7 @@ def royal_road1(individual, order):
     return total,
 
 def royal_road2(individual, order):
-    """Royal Road Function R2 as presented by Melanie Mitchell in : 
+    """Royal Road Function R2 as presented by Melanie Mitchell in :
     "An introduction to Genetic Algorithms".
     """
     total = 0

--- a/deap/benchmarks/binary.py
+++ b/deap/benchmarks/binary.py
@@ -13,15 +13,13 @@
 #    You should have received a copy of the GNU Lesser General Public
 #    License along with DEAP. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division
 
 def bin2float(min_, max_, nbits):
     """Convert a binary array into an array of float where each
     float is composed of *nbits* and is between *min_* and *max_*
     and return the result of the decorated function.
 
-    .. note::
-        This decorator requires the first argument of
-        the evaluation function to be named *individual*.
     """
     def wrap(function):
         def wrapped_function(individual, *args, **kargs):
@@ -31,9 +29,10 @@ def bin2float(min_, max_, nbits):
             decoded = [0] * nelem
             for i in xrange(nelem):
                 gene = int("".join(map(str,
-                                       individual[i*nbits:i*nbits+nbits])), 2)
+                                       individual[i*nbits:i*nbits+nbits])),
+                           2)
                 div = 2**nbits - 1
-                temp = float(gene)/float(div)
+                temp = gene/div
                 decoded[i] = min_ + (temp * (max_ - min_))
             return function(decoded, *args, **kargs)
         return wrapped_function

--- a/deap/benchmarks/binary.py
+++ b/deap/benchmarks/binary.py
@@ -14,6 +14,8 @@
 #    License along with DEAP. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division
+from functools import wraps
+import math
 
 def bin2float(min_, max_, nbits):
     """Convert a binary array into an array of float where each
@@ -22,9 +24,9 @@ def bin2float(min_, max_, nbits):
 
     """
     def wrap(function):
+        @wraps(function)
         def wrapped_function(individual, *args, **kargs):
-            # // Forces the division behavior to be the same in python2 and
-            # python3; user must take care to make nelem an integer.
+            # User must take care to make nelem an integer.
             nelem = len(individual)//nbits
             decoded = [0] * nelem
             for i in xrange(nelem):

--- a/deap/benchmarks/binary.py
+++ b/deap/benchmarks/binary.py
@@ -13,8 +13,8 @@
 #    You should have received a copy of the GNU Lesser General Public
 #    License along with DEAP. If not, see <http://www.gnu.org/licenses/>.
 
-import math
 from __future__ import division
+import math
 
 def bin2float(min_, max_, nbits):
     """Convert a binary array into an array of float where each

--- a/deap/tests/test_algorithms.py
+++ b/deap/tests/test_algorithms.py
@@ -33,7 +33,7 @@ INDCLSNAME = "IND_TYPE"
 
 HV_THRESHOLD = 119.0
 
-    
+
 def setup_func_single_obj():
     creator.create(FITCLSNAME, base.Fitness, weights=(-1.0,))
     creator.create(INDCLSNAME, list, fitness=creator.__dict__[FITCLSNAME])
@@ -57,7 +57,7 @@ def test_cma():
     NDIM = 5
 
     strategy = cma.Strategy(centroid=[0.0]*NDIM, sigma=1.0)
-    
+
     toolbox = base.Toolbox()
     toolbox.register("evaluate", benchmarks.sphere)
     toolbox.register("generate", strategy.generate, creator.__dict__[INDCLSNAME])
@@ -94,15 +94,15 @@ def test_nsga2():
     for gen in range(1, NGEN):
         offspring = tools.selTournamentDCD(pop, len(pop))
         offspring = [toolbox.clone(ind) for ind in offspring]
-        
+
         for ind1, ind2 in zip(offspring[::2], offspring[1::2]):
             if random.random() <= 0.9:
                 toolbox.mate(ind1, ind2)
-            
+
             toolbox.mutate(ind1)
             toolbox.mutate(ind2)
             del ind1.fitness.values, ind2.fitness.values
-        
+
         invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
         fitnesses = toolbox.map(toolbox.evaluate, invalid_ind)
         for ind, fit in zip(invalid_ind, fitnesses):
@@ -152,7 +152,7 @@ def test_mo_cma_es():
         ind.fitness.values = toolbox.evaluate(ind)
 
     strategy = cma.StrategyMultiObjective(population, sigma=1.0, mu=MU, lambda_=LAMBDA)
-    
+
     toolbox.register("generate", strategy.generate, creator.__dict__[INDCLSNAME])
     toolbox.register("update", strategy.update)
 
@@ -164,9 +164,9 @@ def test_mo_cma_es():
         fitnesses = toolbox.map(toolbox.evaluate, population)
         for ind, fit in zip(population, fitnesses):
             ind.fitness.values = fit
-        
+
         # Update the strategy with the evaluated individuals
         toolbox.update(population)
-    
+
     hv = hypervolume(strategy.parents, [11.0, 11.0])
     assert hv > HV_THRESHOLD, "Hypervolume is lower than expected %f < %f" % (hv, HV_THRESHOLD)

--- a/deap/tests/test_benchmarks.py
+++ b/deap/tests/test_benchmarks.py
@@ -1,21 +1,19 @@
 """Test functions from deap/benchmarks."""
-from nose import with_setup
+import sys
 import platform
 import random
 import unittest
+from nose import with_setup
+from past.builtins import xrange
 
 import numpy
 
 from deap import algorithms
 from deap import base
 from deap import benchmarks
-from deap.benchmarks.tools import hypervolume
 from deap import cma
 from deap import creator
 from deap import tools
-
-from past.builtins import xrange
-from deap import creator, base
 from deap.benchmarks import binary
 
 
@@ -38,18 +36,20 @@ class BenchmarkTest(unittest.TestCase):
         del creator.FitnessMin
 
     def test_bin2float(self):
-        """Test deap/benchmarks/binary.py bin2float decorator function."""
 
         zero_individual = creator.Individual([0 for x in xrange(10)])
         full_individual = creator.Individual([1 for x in xrange(10)])
+        two_individiual = creator.Individual(8*[0] + [1, 0])
 
-        population = [zero_individual, full_individual]
+        population = [zero_individual, full_individual, two_individiual]
+
         fitnesses = map(self.toolbox.evaluate, population)
         for ind, fit in zip(population, fitnesses):
             ind.fitness.values = fit
 
         assert population[0].fitness.values == (0.0, )
         assert population[1].fitness.values == (1023.0, )
+        assert population[2].fitness.values == (2.0, )
 
 
 if __name__ == "__main__":

--- a/deap/tests/test_benchmarks.py
+++ b/deap/tests/test_benchmarks.py
@@ -1,19 +1,11 @@
 """Test functions from deap/benchmarks."""
-import sys
-import platform
-import random
 import unittest
 from nose import with_setup
 from past.builtins import xrange
 
-import numpy
-
-from deap import algorithms
 from deap import base
 from deap import benchmarks
-from deap import cma
 from deap import creator
-from deap import tools
 from deap.benchmarks import binary
 
 
@@ -53,5 +45,5 @@ class BenchmarkTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestBenchmark)
+    suite = unittest.TestLoader().loadTestsFromTestCase(BenchmarkTest)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/deap/tests/test_benchmarks.py
+++ b/deap/tests/test_benchmarks.py
@@ -1,4 +1,5 @@
 """Test functions from deap/benchmarks."""
+import sys
 import unittest
 from nose import with_setup
 from past.builtins import xrange
@@ -29,19 +30,33 @@ class BenchmarkTest(unittest.TestCase):
 
     def test_bin2float(self):
 
+        # Correct evaluation of bin2float.
         zero_individual = creator.Individual([0 for x in xrange(10)])
         full_individual = creator.Individual([1 for x in xrange(10)])
         two_individiual = creator.Individual(8*[0] + [1, 0])
-
         population = [zero_individual, full_individual, two_individiual]
-
         fitnesses = map(self.toolbox.evaluate, population)
         for ind, fit in zip(population, fitnesses):
             ind.fitness.values = fit
-
         assert population[0].fitness.values == (0.0, )
         assert population[1].fitness.values == (1023.0, )
         assert population[2].fitness.values == (2.0, )
+
+        # Incorrect evaluation of bin2float.
+        wrong_size_individual = creator.Individual([0, 1, 0, 1, 0, 1, 0, 1, 1])
+        wrong_population = [wrong_size_individual]
+        # It is up the user to make sure that bin2float gets an individual with
+        # an adequate length; no exceptions are raised.
+        fitnesses = map(self.toolbox.evaluate, wrong_population)
+        for ind, fit in zip(wrong_population, fitnesses):
+            # In python 2.7 operator.mul works in a different way than in
+            # python3. Thus an error occurs in python2.7 but an assignment is
+            # correctly executed in python3.
+            if sys.version_info < (3, ):
+                with self.assertRaises(TypeError):
+                    ind.fitness.values = fit
+            else:
+                assert wrong_population[0].fitness.values == ()
 
 
 if __name__ == "__main__":

--- a/deap/tests/test_benchmarks.py
+++ b/deap/tests/test_benchmarks.py
@@ -1,0 +1,57 @@
+"""Test functions from deap/benchmarks."""
+from nose import with_setup
+import platform
+import random
+import unittest
+
+import numpy
+
+from deap import algorithms
+from deap import base
+from deap import benchmarks
+from deap.benchmarks.tools import hypervolume
+from deap import cma
+from deap import creator
+from deap import tools
+
+from past.builtins import xrange
+from deap import creator, base
+from deap.benchmarks import binary
+
+
+class BenchmarkTest(unittest.TestCase):
+    """Test object for unittest of deap/benchmarks."""
+
+    def setUp(self):
+
+        @binary.bin2float(0, 1023, 10)
+        def evaluate(individual):
+            """Simplest evaluation function."""
+            return individual
+
+        creator.create("FitnessMin", base.Fitness, weights=(-1.0,))
+        creator.create("Individual", list, fitness=creator.FitnessMin)
+        self.toolbox = base.Toolbox()
+        self.toolbox.register("evaluate", evaluate)
+
+    def tearDown(self):
+        del creator.FitnessMin
+
+    def test_bin2float(self):
+        """Test deap/benchmarks/binary.py bin2float decorator function."""
+
+        zero_individual = creator.Individual([0 for x in xrange(10)])
+        full_individual = creator.Individual([1 for x in xrange(10)])
+
+        population = [zero_individual, full_individual]
+        fitnesses = map(self.toolbox.evaluate, population)
+        for ind, fit in zip(population, fitnesses):
+            ind.fitness.values = fit
+
+        assert population[0].fitness.values == (0.0, )
+        assert population[1].fitness.values == (1023.0, )
+
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestBenchmark)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/deap/tests/test_creator.py
+++ b/deap/tests/test_creator.py
@@ -49,7 +49,7 @@ def test_array():
     creator.create(CNAME, array.array, typecode="i")
     a = creator.__dict__[CNAME]([1,2,3,4])
     b = creator.__dict__[CNAME]([5,6,7,8])
-    
+
     a[1:3], b[1:3] = b[1:3], a[1:3]
     ta = array.array("i", [1,6,7,4])
     tb = array.array("i", [5,2,3,8])
@@ -62,7 +62,7 @@ def test_numpy_nocopy():
     creator.create(CNAME, numpy.ndarray)
     a = creator.__dict__[CNAME]([1,2,3,4])
     b = creator.__dict__[CNAME]([5,6,7,8])
-    
+
     a[1:3], b[1:3] = b[1:3], a[1:3]
     ta = numpy.array([1,6,7,4])
     tb = numpy.array([5,6,7,8])
@@ -75,7 +75,7 @@ def test_numpy_copy():
     creator.create(CNAME, numpy.ndarray)
     a = creator.__dict__[CNAME]([1,2,3,4])
     b = creator.__dict__[CNAME]([5,6,7,8])
-    
+
     a[1:3], b[1:3] = b[1:3].copy(), a[1:3].copy()
     ta = numpy.array([1,6,7,4])
     tb = numpy.array([5,2,3,8])

--- a/deap/tests/test_logbook.py
+++ b/deap/tests/test_logbook.py
@@ -33,7 +33,7 @@ class LogbookTest(unittest.TestCase):
 
     def test_no_chapters(self):
         self.logbook.record(gen=0, evals=100, **{'avg' : 1.0, 'max' : 10})
-        self.logbook.record(gen=0, evals=100, **{'avg' : 1.0, 'max' : 10})        
+        self.logbook.record(gen=0, evals=100, **{'avg' : 1.0, 'max' : 10})
         print(self.logbook.stream)
 
 
@@ -41,4 +41,4 @@ class LogbookTest(unittest.TestCase):
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(LogbookTest)
     unittest.TextTestRunner(verbosity=2).run(suite)
-    
+

--- a/deap/tests/test_pickle.py
+++ b/deap/tests/test_pickle.py
@@ -34,7 +34,7 @@ class Pickling(unittest.TestCase):
         del creator.IndArray
         del creator.IndNDArray
         del creator.IndTree
-    
+
     def test_pickle_fitness(self):
         fitness = creator.FitnessMax()
         fitness.values = (1.0,)
@@ -49,7 +49,7 @@ class Pickling(unittest.TestCase):
         ind_l = pickle.loads(ind_s)
         self.assertEqual(ind, ind_l, "Unpickled individual list != pickled individual list")
         self.assertEqual(ind.fitness, ind_l.fitness, "Unpickled individual fitness != pickled individual fitness")
-         
+
     def test_pickle_ind_array(self):
         ind = creator.IndArray([1.0, 2.0, 3.0])
         ind.fitness.values = (4.0,)
@@ -66,7 +66,7 @@ class Pickling(unittest.TestCase):
         ind_l = pickle.loads(ind_s)
         self.assertTrue(all(ind == ind_l), "Unpickled individual numpy.ndarray != pickled individual numpy.ndarray")
         self.assertEqual(ind.fitness, ind_l.fitness, "Unpickled individual fitness != pickled individual fitness")
-    
+
     def test_pickle_tree_input(self):
         pset = gp.PrimitiveSetTyped("MAIN", [int], int, "IN")
         pset.addPrimitive(operator.add, [int, int], int)
@@ -118,19 +118,19 @@ class Pickling(unittest.TestCase):
         ind2.fitness.values = (2.0,)
         ind3 = creator.IndList([7.0,8.0,9.0])
         ind3.fitness.values = (3.0,)
-        
+
         pop = [ind1, ind2, ind3]
-        
+
         pop_s = pickle.dumps(pop)
         pop_l = pickle.loads(pop_s)
-        
+
         self.assertEqual(pop[0], pop_l[0], "Unpickled individual list != pickled individual list")
         self.assertEqual(pop[0].fitness, pop_l[0].fitness, "Unpickled individual fitness != pickled individual fitness")
         self.assertEqual(pop[1], pop_l[1], "Unpickled individual list != pickled individual list")
         self.assertEqual(pop[1].fitness, pop_l[1].fitness, "Unpickled individual fitness != pickled individual fitness")
         self.assertEqual(pop[2], pop_l[2], "Unpickled individual list != pickled individual list")
         self.assertEqual(pop[2].fitness, pop_l[2].fitness, "Unpickled individual fitness != pickled individual fitness")
-    
+
     @unittest.skipIf(platform.python_implementation() == "PyPy", "PyPy support for pickling ndarrays (thus stats) is very unstable.")
     def test_pickle_logbook(self):
         stats = tools.Statistics()
@@ -145,14 +145,13 @@ class Pickling(unittest.TestCase):
 
         self.assertEqual(logbook, logbook_r, "Unpickled logbook != pickled logbook")
 
-        
     @unittest.skipIf(sys.version_info < (2, 7), "Skipping test because Python version < 2.7 does not pickle partials.")
     def test_pickle_partial(self):
         func_s = pickle.dumps(self.toolbox.func)
         func_l = pickle.loads(func_s)
 
         self.assertEqual(self.toolbox.func(), func_l())
-        
+
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(Pickling)

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ def run_setup(build_ext):
             'Topic :: Software Development',
             ],
          ext_modules = extra_modules,
-         cmdclass = {'build_py': build_py, "build_ext" : ve_build_ext}
+         cmdclass = {'build_py': build_py, "build_ext" : ve_build_ext},
+         use_2to3=True
     )
 
 try:


### PR DESCRIPTION
## Fixed bin2float behavior

A difference in integer division from python2 to python3 causes error when using bin2float.

In python2: `3/2` is `1` and in python3 `3/2` is `1.5`. The latter causes:
`TypeError: can't multiply sequence by non-int of type 'float'` in `in wrapped_function decoded = [0] * nelem`.

This pull request fix this error making this decorator usable in both python2 and 3.

## Added a new test file for benchmarks.py

This pull request also creates a test file for the benchmarks module.

## Other

Other files were also changed to comply with pep8.