### PR TITLE
ParetoFront: skip useless domination tests in update()

### DIFF
--- a/deap/tools/support.py
+++ b/deap/tools/support.py
@@ -614,13 +614,15 @@ class ParetoFront(HallOfFame):
         """
         for ind in population:
             is_dominated = False
+            dominates_one = False
             has_twin = False
             to_remove = []
             for i, hofer in enumerate(self):    # hofer = hall of famer
-                if hofer.fitness.dominates(ind.fitness):
+                if not dominates_one and hofer.fitness.dominates(ind.fitness):
                     is_dominated = True
                     break
                 elif ind.fitness.dominates(hofer.fitness):
+                    dominates_one = True
                     to_remove.append(i)
                 elif ind.fitness == hofer.fitness and self.similar(ind, hofer):
                     has_twin = True


### PR DESCRIPTION
Skip "ind is dominated by hofer" check if it dominates one of them already.

See https://github.com/DEAP/deap/issues/189.

I removed the `has_twin` condition from my proposal:

```
    - if not dominates_one and not has_twin and hofer.fitness.dominates(ind.fitness):
    + if not dominates_one and hofer.fitness.dominates(ind.fitness):
```
because a twin may be dominated so this was abusive.