### PR TITLE
You've said that the knapsack set will employ SPEA2, yet example code…

### DIFF
--- a/doc/examples/ga_knapsack.rst
+++ b/doc/examples/ga_knapsack.rst
@@ -52,8 +52,8 @@ input individual.
 
 
 We then register these operators in the toolbox. Since it is a multi-objective
-problem, we have selected the SPEA-II selection scheme : 
-:func:`~deap.tools.selSPEA2`
+problem, we have selected the NSGA-II selection scheme : 
+:func:`~deap.tools.selNSGA2`
 
 .. literalinclude:: /../examples/ga/knapsack.py
    :lines: 83-86


### PR DESCRIPTION
… is using NGSA2

Either these docs or the example code needs to be changed. I'm assuming from the referenced literature that NGSA2 is the choice in this change.