### PR TITLE
Added support for empty population in HallOfFame.update

### DIFF
--- a/deap/tools/support.py
+++ b/deap/tools/support.py
@@ -517,24 +517,25 @@ class HallOfFame(object):
         :param population: A list of individual with a fitness attribute to
                            update the hall of fame with.
         """
-        if len(self) == 0 and self.maxsize !=0:
-            # Working on an empty hall of fame is problematic for the
-            # "for else"
-            self.insert(population[0])
-        
-        for ind in population:
-            if ind.fitness > self[-1].fitness or len(self) < self.maxsize:
-                for hofer in self:
-                    # Loop through the hall of fame to check for any
-                    # similar individual
-                    if self.similar(ind, hofer):
-                        break
-                else:
-                    # The individual is unique and strictly better than
-                    # the worst
-                    if len(self) >= self.maxsize:
-                        self.remove(-1)
-                    self.insert(ind)
+        if population:
+            if len(self) == 0 and self.maxsize !=0:
+                # Working on an empty hall of fame is problematic for the
+                # "for else"
+                self.insert(population[0])
+            
+            for ind in population:
+                if ind.fitness > self[-1].fitness or len(self) < self.maxsize:
+                    for hofer in self:
+                        # Loop through the hall of fame to check for any
+                        # similar individual
+                        if self.similar(ind, hofer):
+                            break
+                    else:
+                        # The individual is unique and strictly better than
+                        # the worst
+                        if len(self) >= self.maxsize:
+                            self.remove(-1)
+                        self.insert(ind)
     
     def insert(self, item):
         """Insert a new individual in the hall of fame using the

--- a/deap/tools/support.py
+++ b/deap/tools/support.py
@@ -517,25 +517,24 @@ class HallOfFame(object):
         :param population: A list of individual with a fitness attribute to
                            update the hall of fame with.
         """
-        if population:
-            if len(self) == 0 and self.maxsize !=0:
-                # Working on an empty hall of fame is problematic for the
-                # "for else"
-                self.insert(population[0])
-            
-            for ind in population:
-                if ind.fitness > self[-1].fitness or len(self) < self.maxsize:
-                    for hofer in self:
-                        # Loop through the hall of fame to check for any
-                        # similar individual
-                        if self.similar(ind, hofer):
-                            break
-                    else:
-                        # The individual is unique and strictly better than
-                        # the worst
-                        if len(self) >= self.maxsize:
-                            self.remove(-1)
-                        self.insert(ind)
+        if len(self) == 0 and self.maxsize !=0 and len(population) > 0:
+            # Working on an empty hall of fame is problematic for the
+            # "for else"
+            self.insert(population[0])
+        
+        for ind in population:
+            if ind.fitness > self[-1].fitness or len(self) < self.maxsize:
+                for hofer in self:
+                    # Loop through the hall of fame to check for any
+                    # similar individual
+                    if self.similar(ind, hofer):
+                        break
+                else:
+                    # The individual is unique and strictly better than
+                    # the worst
+                    if len(self) >= self.maxsize:
+                        self.remove(-1)
+                    self.insert(ind)
     
     def insert(self, item):
         """Insert a new individual in the hall of fame using the


### PR DESCRIPTION
Sometimes it's useful to filter out a set of individuals and then updating the HoF with them. In that filtering process, it could be possible to end up with no individuals.

Nonetheless, when trying to update an empty HoF with an empty sequence as input, an IndexError would be raised because it would try to access a nonexistent zeroth element. I think that this is not an intuitive behaviour, as the HoF should have no problem dealing with an empty population update.

This simple check could avoid having to check if the population is empty every single time in user code.