### PR TITLE
Fix dtlz7 benchmark problem implementation

### DIFF
--- a/deap/benchmarks/__init__.py
+++ b/deap/benchmarks/__init__.py
@@ -623,7 +623,7 @@ def dtlz7(ind, n_objs):
     Optimization Test Problems. CEC 2002, p. 825-830, IEEE Press, 2002.
     """
     gval = 1 + 9.0 / len(ind[n_objs-1:]) * sum([a for a in ind[n_objs-1:]])
-    fit = [ind for ind in ind[:n_objs-1]]
+    fit = [x for x in ind[:n_objs-1]]
     fit.append((1 + gval) * (n_objs - sum([a / (1.0 + gval) * (1 + sin(3 * pi * a)) for a in ind[:n_objs-1]])))
     return fit
 


### PR DESCRIPTION
dtlz7 function used to raise ``TypeError: 'float' object has no attribute
'__getitem__'`` on each call.

Problem rose, because the same variable name ``ind`` was used both to
store coordinates of the individual and as a temporal variable in a loop.
Temporal variable used to override the original one used to store coordinates
of the individual. Problem fixed by using different name for the temporal variable.