### PR TITLE
exchange the position of individual and norder in binary.royal_road2

### DIFF
--- a/deap/benchmarks/binary.py
+++ b/deap/benchmarks/binary.py
@@ -138,6 +138,6 @@ def royal_road2(individual, order):
     total = 0
     norder = order
     while norder < order**2:
-        total += royal_road1(norder, individual)[0]
+        total += royal_road1(individual, norder)[0]
         norder *= 2
     return total,


### PR DESCRIPTION
The usage of royal_road1 in royal_road2 is wrong because the order of parameters is reversed.
Now fix it.
