### PR TITLE
Add two constants which are used later.

### DIFF
--- a/doc/examples/ga_onemax.rst
+++ b/doc/examples/ga_onemax.rst
@@ -162,6 +162,11 @@ We :func:`map` the evaluation function to every individual and then assign
 their respective fitness. Note that the order in ``fitnesses`` and
 ``population`` is the same.
 
+Before we go on, this is the time to define some constants we will use later on.
+
+.. literalinclude:: /../examples/ga/onemax.py
+   :lines: 79-83
+
 -----------------------
 Performing the Evolution
 -----------------------


### PR DESCRIPTION
Without it, the code from the tutorial alone doesn't work, since the two variables CXPB and MUTPB are not defined. With those lines, the code from the ga_onemax.rst works fine.