### PR TITLE
Add numpy to installation requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ def run_setup(build_ext):
             ],
          ext_modules = extra_modules,
          cmdclass = {"build_ext" : ve_build_ext},
+         install_requires = ['numpy'],
          use_2to3=True
     )
 


### PR DESCRIPTION
`setup.py` of this PR installs `numpy` if it is not available during the installation process of `deap`.
Now that [`deap.tools.indicator`](https://github.com/toshihikoyanase/deap/blob/d9608eabaf6e5234bd9140f41118cee6220a2c60/deap/tools/indicator.py#L17) depends on `numpy`,  users who installed only deap will encounter `ImportError` when they try to import `deap.tools` as follows:

```shell
>>> from deap import tools
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "deap/tools/__init__.py", line 26, in <module>
    from .indicator import *
  File "deap/tools/indicator.py", line 17, in <module>
    import numpy
ImportError: No module named numpy
```

And some other files such as `deap.tools.constraint` and `deap.tools.selection.py` also require `numpy`.