### PR TITLE
Add remove() method in creator.py

### DIFF
--- a/deap/creator.py
+++ b/deap/creator.py
@@ -169,3 +169,13 @@ def create(name, base, **kargs):
     objtype = type(str(name), (base,), dict_cls)
     objtype.__init__ = initType
     globals()[name] = objtype
+
+
+def remove(name):
+    """
+    Remove a class created by :func:`create`.
+    """
+    try:
+        globals().pop(name)
+    except KeyError:
+        pass


### PR DESCRIPTION
In function [create()](https://github.com/DEAP/deap/blob/82f774d9be6bad4b9d88272ba70ed6f1fca39fcf/deap/creator.py#L96) a warning is shown 
if a class has previously been created with the same name ([here](https://github.com/DEAP/deap/blob/82f774d9be6bad4b9d88272ba70ed6f1fca39fcf/deap/creator.py#L138))
It says "Consider deleting previous creation of that class or rename it" but `creator` provides
no ways to do that.

This PR adds a method `remove()` that let the user remove a previously created class.
