### PR TITLE
Incorrect usage of itertools.repeat

### DIFF
--- a/deap/benchmarks/tools.py
+++ b/deap/benchmarks/tools.py
@@ -242,7 +242,7 @@ class bound(object):
         try:
             self.bounds = tuple(bounds)
         except TypeError:
-            self.bounds = itertools.repeat(bounds)
+            self.bounds = repeat(bounds)
 
         if type == "mirror":
             self.bound = self._mirror


### PR DESCRIPTION
The function itertools.repeat in bound.__init__ was called using 'itertools.repeat', while the function was imported using 'from itertools import repeat'.