### PR TITLE
Added try except ImportError for collections.abc which will require a…

### DIFF
--- a/deap/base.py
+++ b/deap/base.py
@@ -20,7 +20,11 @@ class used as base class, for the fitness member of any individual. """
 
 import sys
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
+
 from copy import deepcopy
 from functools import partial
 from operator import mul, truediv

--- a/deap/benchmarks/movingpeaks.py
+++ b/deap/benchmarks/movingpeaks.py
@@ -24,7 +24,11 @@ Optima.*
 import math
 import itertools
 import random
-from collections import Sequence
+
+try:
+    from collections.abc import Sequence
+except:
+    from colections import Sequence
 
 def cone(individual, position, height, width):
     """The cone peak function to be used with scenario 2 and 3.

--- a/deap/benchmarks/movingpeaks.py
+++ b/deap/benchmarks/movingpeaks.py
@@ -28,7 +28,7 @@ import random
 try:
     from collections.abc import Sequence
 except:
-    from colections import Sequence
+    from collections import Sequence
 
 def cone(individual, position, height, width):
     """The cone peak function to be used with scenario 2 and 3.

--- a/deap/tools/constraint.py
+++ b/deap/tools/constraint.py
@@ -1,7 +1,11 @@
 
 from functools import wraps
 from itertools import repeat
-from collections import Sequence
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 class DeltaPenalty(object):
     """This decorator returns penalized fitness for invalid individuals and the

--- a/deap/tools/crossover.py
+++ b/deap/tools/crossover.py
@@ -2,7 +2,11 @@ from __future__ import division
 import random
 import warnings
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
+
 from itertools import repeat
 
 

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -3,8 +3,11 @@ import math
 import random
 
 from itertools import repeat
-from collections import Sequence
 
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 ######################################
 # GA Mutations                       #


### PR DESCRIPTION
… change from Python 3.8. Style follows similar usage elsewhere in deep.

Also easy to drop try/except when Python 2.7 may not be supported in the future.

Addresses Issue #394 