### PR TITLE
fix literalinclude ranges for pso basic

### DIFF
--- a/doc/examples/pso_basic.rst
+++ b/doc/examples/pso_basic.rst
@@ -18,7 +18,7 @@ Before writing functions and algorithms, we need to import some module from
 the standard library and from DEAP.
 
 .. literalinclude:: /../examples/pso/basic.py
-   :lines: 16-24
+   :lines: 16-25
 
 Representation
 ==============
@@ -34,7 +34,7 @@ best state in which it has been so far.
 This translates in DEAP by the following two lines of code :
 
 .. literalinclude:: /../examples/pso/basic.py
-   :lines: 26-28
+   :lines: 27-29
 
 Here we create two new objects in the :mod:`~deap.creator` space. First, we
 create a :class:`FitnessMax` object, and we specify the
@@ -79,7 +79,7 @@ function is already defined in the benchmarks module, so we can register it
 directly.
 
 .. literalinclude:: /../examples/pso/basic.py
-   :lines: 50-54
+   :lines: 51-55
 
 Algorithm
 =========


### PR DESCRIPTION
I noticed that the code snippets in [Particle Swarm Optimization Basics](https://deap.readthedocs.io/en/master/examples/pso_basic.html) were missing some lines. 

The solution is simply to update [doc/examples/pso_basic.rst](https://github.com/DEAP/deap/blob/master/doc/examples/pso_basic.rst) with the correct references to [examples/pso/basic.py](https://github.com/DEAP/deap/blob/master/examples/pso/basic.py)