### PR TITLE
Adapt conf.py for sphinx >= 2.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -182,7 +182,7 @@ html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    'index': 'indexsidebar.html',
+    'index': ['indexsidebar.html'],
 }
 
 # Additional templates that should be rendered to pages, maps page names to


### PR DESCRIPTION
html_sidebars dict values must now be a list.

Resolves a TemplateNotFound exception raised when building the documentation
with sphinx 2.4, as encountered when building the Debian packages.

http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars