### PR TITLE
Fix the docstring of isDominated function

### DIFF
--- a/deap/tools/emo.py
+++ b/deap/tools/emo.py
@@ -204,7 +204,7 @@ def identity(obj):
     return obj
 
 def isDominated(wvalues1, wvalues2):
-    """Returns whether or not *wvalues1* dominates *wvalues2*.
+    """Returns whether or not *wvalues2* dominates *wvalues1*.
 
     :param wvalues1: The weighted fitness values that would be dominated.
     :param wvalues2: The weighted fitness values of the dominant.


### PR DESCRIPTION
### Related issue
https://github.com/DEAP/deap/issues/453

### Summary
Fix the docstring of `isDominated` funciton.

As far as the code described below is concerned, when all `wvalues2`'s value are greater than all `wvalues1`'s ones, this function returns `True`.
```
        elif self_wvalue < other_wvalue:
            not_equal = True
    return not_equal
```
I suppose it is the opposite of the current docstring description.
I also think the current description below is correct.
```
    :returns: :obj:`True` if wvalues2 dominates wvalues1, :obj:`False`
              otherwise.
```

This is my first pull request for Deap.
I would appreciate it if you review it, and let me know if you find any problems on this pull request.

Thank you very much!