### PR TITLE
addPrimitive now checks where primitive is a callable and has the same number of parameters as the ones specified in_types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ MANIFEST
 *.orig
 .DS_Store
 *.so
+
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -1,39 +1,48 @@
 #!/usr/bin/env python
+import codecs
 import sys
+from os import path
 
 warnings = list()
 
 try:
     from setuptools import setup, Extension, find_packages
+
     modules = find_packages(exclude=['examples'])
 except ImportError:
-    warnings.append("warning: using distutils.core.setup, cannot use \"develop\" option")
+    warnings.append(
+        "warning: using distutils.core.setup, cannot use \"develop\" option")
     from distutils.core import setup, Extension
-    modules = ['deap', 'deap.benchmarks', 'deap.tests', 'deap.tools', 'deap.tools._hypervolume']
+
+    modules = ['deap', 'deap.benchmarks', 'deap.tests', 'deap.tools',
+               'deap.tools._hypervolume']
 
 from setuptools.command.build_ext import build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError
 
 # read the contents of README file
-from os import path
-import codecs
+
+
 this_directory = path.abspath(path.dirname(__file__))
-long_description = codecs.open(path.join(this_directory, 'README.md'), 'r', 'utf-8').read()
+long_description = codecs.open(path.join(this_directory, 'README.md'), 'r',
+                               'utf-8').read()
 
 import deap
 
 if sys.platform == 'win32' and sys.version_info > (2, 6):
-   # 2.6's distutils.msvc9compiler can raise an IOError when failing to
-   # find the compiler
-   # It can also raise ValueError http://bugs.python.org/issue7511
-   ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError,
-                 IOError, ValueError)
+    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
+    # find the compiler
+    # It can also raise ValueError http://bugs.python.org/issue7511
+    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError,
+                  IOError, ValueError)
 else:
-   ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+
 
 class BuildFailed(Exception):
     pass
+
 
 class ve_build_ext(build_ext):
     # This class allows C extension building to fail.
@@ -52,12 +61,15 @@ class ve_build_ext(build_ext):
             print(e)
             raise BuildFailed()
 
+
 def run_setup(build_ext):
     extra_modules = None
     if build_ext:
         extra_modules = list()
 
-        hv_module = Extension("deap.tools._hypervolume.hv", sources=["deap/tools/_hypervolume/_hv.c", "deap/tools/_hypervolume/hv.cpp"])
+        hv_module = Extension("deap.tools._hypervolume.hv",
+                              sources=["deap/tools/_hypervolume/_hv.c",
+                                       "deap/tools/_hypervolume/hv.cpp"])
         extra_modules.append(hv_module)
 
     setup(name='deap',
@@ -69,26 +81,35 @@ def run_setup(build_ext):
           author_email='deap-users@googlegroups.com',
           url='https://www.github.com/deap',
           packages=find_packages(exclude=['examples']),
-        #   packages=['deap', 'deap.tools', 'deap.tools._hypervolume', 'deap.benchmarks', 'deap.tests'],
+          # packages=['deap', 'deap.tools', 'deap.tools._hypervolume',
+          # 'deap.benchmarks', 'deap.tests'],
           platforms=['any'],
-          keywords=['evolutionary algorithms', 'genetic algorithms', 'genetic programming', 'cma-es', 'ga', 'gp', 'es', 'pso'],
+          keywords=['evolutionary algorithms',
+                    'genetic algorithms',
+                    'genetic programming',
+                    'cma-es',
+                    'ga',
+                    'gp',
+                    'es',
+                    'pso'],
           license='LGPL',
           classifiers=[
-            'Development Status :: 4 - Beta',
-            'Intended Audience :: Developers',
-            'Intended Audience :: Education',
-            'Intended Audience :: Science/Research',
-            'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 3',
-            'Topic :: Scientific/Engineering',
-            'Topic :: Software Development',
-            ],
-         ext_modules=extra_modules,
-         cmdclass={"build_ext": ve_build_ext},
-         install_requires=['numpy'],
-         use_2to3=True
-    )
+              'Development Status :: 4 - Beta',
+              'Intended Audience :: Developers',
+              'Intended Audience :: Education',
+              'Intended Audience :: Science/Research',
+              'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
+              'Programming Language :: Python',
+              'Programming Language :: Python :: 3',
+              'Topic :: Scientific/Engineering',
+              'Topic :: Software Development',
+          ],
+          ext_modules=extra_modules,
+          cmdclass={"build_ext": ve_build_ext},
+          install_requires=['numpy'],
+          use_2to3=True
+          )
+
 
 try:
     run_setup(True)


### PR DESCRIPTION
I changed 3 files

- `.gitignore` to add `.idea/` for those that work PyCharm
- `setup.py`: I just formatted it with pep8 (with PyCharm) and moved one import to the top of the file
- `deap/gp.py`: here, are the main changes and are described in the title: 
      - so why these changes? Because I noticed that you can trick deap into thinking that the inputs of a primitive are, say, `[A, B, C]`, while the function could have a different signature, and nothing wrong happens. These changes make sure that at least that 
          1. the parameter `primitive` is a `callable`
          2. the number of parameters that `primitive` accepts is equal to the number of parameters specified in `in_types`. We could do other checks, but these are the ones that we can surely do and they are done only at the creation of the primitive set, so this should not cause runtime slowdowns (or stuff like that). I used `2to3` to make sure that the code is converted correctly to Python 3, and it seems to be the case. Specifically, `primitive.func_code.co_argcount != len(in_types)` is replaced with `primitive.__code__.co_argcount != len(in_types)`.