### PR TITLE
Fix divided by zero in selNSGA3

### DIFF
--- a/deap/tools/emo.py
+++ b/deap/tools/emo.py
@@ -591,12 +591,15 @@ def find_intercepts(extreme_points, best_point, current_worst, front_worst):
     except numpy.linalg.LinAlgError:
         intercepts = current_worst
     else:
-        intercepts = 1 / x
-
-        if (not numpy.allclose(numpy.dot(A, x), b) or
-                numpy.any(intercepts <= 1e-6) or
-                numpy.any((intercepts + best_point) > current_worst)):
+        if numpy.count_nonzero(x) != len(x):
             intercepts = front_worst
+        else:
+            intercepts = 1 / x
+
+            if (not numpy.allclose(numpy.dot(A, x), b) or
+                    numpy.any(intercepts <= 1e-6) or
+                    numpy.any((intercepts + best_point) > current_worst)):
+                intercepts = front_worst
 
     return intercepts
 


### PR DESCRIPTION
I had an issue with a division by zero in the find_intercepts function (https://github.com/DEAP/deap/issues/534).

Apparently this is caused by numpy.linalg.solve which sometimes does not detect the singularity of the input matrix and thus does not throw an exception (https://github.com/numpy/numpy/issues/10471).

This pull request would fix this issue by detecting solutions with zeros.
