### PR TITLE
Use raw docstrings when LaTex is embedded

### DIFF
--- a/deap/algorithms.py
+++ b/deap/algorithms.py
@@ -31,7 +31,7 @@ import tools
 
 
 def varAnd(population, toolbox, cxpb, mutpb):
-    """Part of an evolutionary algorithm applying only the variation part
+    r"""Part of an evolutionary algorithm applying only the variation part
     (crossover **and** mutation). The modified individuals have their
     fitness invalidated. The individuals are cloned so returned population is
     independent of the input population.
@@ -190,7 +190,7 @@ def eaSimple(population, toolbox, cxpb, mutpb, ngen, stats=None,
 
 
 def varOr(population, toolbox, lambda_, cxpb, mutpb):
-    """Part of an evolutionary algorithm applying only the variation part
+    r"""Part of an evolutionary algorithm applying only the variation part
     (crossover, mutation **or** reproduction). The modified individuals have
     their fitness invalidated. The individuals are cloned so returned
     population is independent of the input population.
@@ -247,7 +247,7 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
 
 def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen,
                    stats=None, halloffame=None, verbose=__debug__):
-    """This is the :math:`(\mu + \lambda)` evolutionary algorithm.
+    r"""This is the :math:`(\mu + \lambda)` evolutionary algorithm.
 
     :param population: A list of individuals.
     :param toolbox: A :class:`~deap.base.Toolbox` that contains the evolution
@@ -339,7 +339,7 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen,
 
 def eaMuCommaLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen,
                     stats=None, halloffame=None, verbose=__debug__):
-    """This is the :math:`(\mu~,~\lambda)` evolutionary algorithm.
+    r"""This is the :math:`(\mu~,~\lambda)` evolutionary algorithm.
 
     :param population: A list of individuals.
     :param toolbox: A :class:`~deap.base.Toolbox` that contains the evolution

--- a/deap/tools/constraint.py
+++ b/deap/tools/constraint.py
@@ -8,7 +8,7 @@ except ImportError:
     from collections import Sequence
 
 class DeltaPenalty(object):
-    """This decorator returns penalized fitness for invalid individuals and the
+    r"""This decorator returns penalized fitness for invalid individuals and the
     original fitness value for valid individuals. The penalized fitness is made
     of a constant factor *delta* added with an (optional) *distance* penalty. The
     distance function, if provided, shall return a value growing as the
@@ -66,7 +66,7 @@ class DeltaPenalty(object):
 DeltaPenality = DeltaPenalty
 
 class ClosestValidPenalty(object):
-    """This decorator returns penalized fitness for invalid individuals and the
+    r"""This decorator returns penalized fitness for invalid individuals and the
     original fitness value for valid individuals. The penalized fitness is made
     of the fitness of the closest valid individual added with a weighted
     (optional) *distance* penalty. The distance function, if provided, shall

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -178,7 +178,7 @@ def mutUniformInt(individual, low, up, indpb):
 ######################################
 
 def mutESLogNormal(individual, c, indpb):
-    """Mutate an evolution strategy according to its :attr:`strategy`
+    r"""Mutate an evolution strategy according to its :attr:`strategy`
     attribute as described in [Beyer2002]_. First the strategy is mutated
     according to an extended log normal rule, :math:`\\boldsymbol{\sigma}_t =
     \\exp(\\tau_0 \mathcal{N}_0(0, 1)) \\left[ \\sigma_{t-1, 1}\\exp(\\tau


### PR DESCRIPTION
Precisely what the title says. Avoids invalid escape sequence related warnings in Python 3.7 and onwards. See https://lwn.net/Articles/795546/ for further reference.