### PR TITLE
Inversion Mutation

### DIFF
--- a/deap/tests/test_mutation.py
+++ b/deap/tests/test_mutation.py
@@ -1,0 +1,43 @@
+import unittest
+import mock
+
+from deap.tools.mutation import mutInversion
+
+class MutationTest(unittest.TestCase):
+
+    def test_mutInverstion_empty_chromosome_raises_value_error_from_randrange(self):
+        with self.assertRaises(ValueError, msg="empty range for randrange()"):
+            mutInversion([])
+
+    def test_mutInversion_size_one_chromosome_returns_unchanged_chromosome_in_tuple(self):
+        chromosome = ["a"]
+        expected = ["a"]
+        self.assertEqual((expected,), mutInversion(chromosome))
+
+    @mock.patch("random.randrange")
+    def test_mutInversion_same_random_indices_returns_unchanged_chromosome_in_tuple(self, mock_randrange):
+        mock_randrange.side_effect = [2, 2]
+        chromosome = ["a", "b", "c", "d", "e"]
+        expected = ["a", "b", "c", "d", "e"]
+        self.assertEqual((expected,), mutInversion(chromosome))
+
+    @mock.patch("random.randrange")
+    def test_mutInversion_difference_of_one_random_indices_returns_unchanged_chromosome_in_tuple(self, mock_randrange):
+        mock_randrange.side_effect = [2, 3]
+        chromosome = ["a", "b", "c", "d", "e"]
+        expected = ["a", "b", "c", "d", "e"]
+        self.assertEqual((expected,), mutInversion(chromosome))
+
+    @mock.patch("random.randrange")
+    def test_mutInversion_full_length_random_indices_returns_reversed_chromosome_in_tuple(self, mock_randrange):
+        mock_randrange.side_effect = [0, 5]
+        chromosome = ["a", "b", "c", "d", "e"]
+        expected = ["e", "d", "c", "b", "a"]
+        self.assertEqual((expected,), mutInversion(chromosome))
+
+    @mock.patch("random.randrange")
+    def test_mutInversion_general_case_returns_correctly_mutated_chromosome_in_tuple(self, mock_randrange):
+        mock_randrange.side_effect = [1, 4]
+        chromosome = ["a", "b", "c", "d", "e"]
+        expected = ["a", "d", "c", "b", "e"]
+        self.assertEqual((expected,), mutInversion(chromosome))

--- a/deap/tests/test_mutation.py
+++ b/deap/tests/test_mutation.py
@@ -5,9 +5,10 @@ from deap.tools.mutation import mutInversion
 
 class MutationTest(unittest.TestCase):
 
-    def test_mutInverstion_empty_chromosome_raises_value_error_from_randrange(self):
-        with self.assertRaises(ValueError, msg="empty range for randrange()"):
-            mutInversion([])
+    def test_mutInverstion_size_zero_chromosome_returns_unchanged_chromosome_in_tuple(self):
+        chromosome = []
+        expected = []
+        self.assertEqual((expected,), mutInversion(chromosome))
 
     def test_mutInversion_size_one_chromosome_returns_unchanged_chromosome_in_tuple(self):
         chromosome = ["a"]

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -175,7 +175,7 @@ def mutUniformInt(individual, low, up, indpb):
 
 def mutInversion(individual):
     """Select two points (indices) in the individual, reverse the order of the
-    attributes between these points [low, high) and return the mutated individual.
+    attributes between these points [low, high] and return the mutated individual.
     This implementation allows for the length of the inversion to be 0 and 1,
     which would cause no change. This mutation is useful in situations where the
     order/adjacency of elements is important.
@@ -187,11 +187,18 @@ def mutInversion(individual):
     :mod:`random` module.
     """
 
+    # Select two random indices
     size = len(individual)
     index_one = random.randrange(size)
-    index_two = random.randrange(index_one, size)
+    index_two = random.randrange(size)
+    start_index = min(index_one, index_two)
+    end_index = max(index_one, index_two)
 
-    
+    # Reverse the contents of the individual between the indices
+    while start_index < end_index:
+        individual[start_index], individual[end_index] = individual[end_index], individual[start_index]
+        start_index += 1
+        end_index -= 1
 
     return individual,
 

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -246,4 +246,4 @@ def mutESLogNormal(individual, c, indpb):
 
 
 __all__ = ['mutGaussian', 'mutPolynomialBounded', 'mutShuffleIndexes',
-           'mutFlipBit', 'mutUniformInt', 'mutESLogNormal']
+           'mutFlipBit', 'mutUniformInt', 'mutInversion', 'mutESLogNormal']

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -187,9 +187,10 @@ def mutInversion(individual):
     This function uses the :func:`~random.random` function from the python base
     :mod:`random` module.
     """
-
-    # Select two random indices
     size = len(individual)
+    if size == 0:
+        return individual,
+
     index_one = random.randrange(size)
     index_two = random.randrange(size)
     start_index = min(index_one, index_two)

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -197,7 +197,7 @@ def mutInversion(individual):
 
     # Reverse the contents of the individual between the indices
     while start_index < end_index - 1:
-        individual[start_index], individual[end_index] = individual[end_index], individual[start_index]
+        individual[start_index], individual[end_index - 1] = individual[end_index - 1], individual[start_index]
         start_index += 1
         end_index -= 1
 

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -173,6 +173,29 @@ def mutUniformInt(individual, low, up, indpb):
     return individual,
 
 
+def mutInversion(individual):
+    """Select two points (indices) in the individual, reverse the order of the
+    attributes between these points [low, high) and return the mutated individual.
+    This implementation allows for the length of the inversion to be 0 and 1,
+    which would cause no change. This mutation is useful in situations where the
+    order/adjacency of elements is important.
+
+    :param individual: Individual to be mutated.
+    :returns: A tuple of one individual.
+
+    This function uses the :func:`~random.random` function from the python base
+    :mod:`random` module.
+    """
+
+    size = len(individual)
+    index_one = random.randrange(size)
+    index_two = random.randrange(index_one, size)
+
+    
+
+    return individual,
+
+
 ######################################
 # ES Mutations                       #
 ######################################

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -196,10 +196,7 @@ def mutInversion(individual):
     end_index = max(index_one, index_two)
 
     # Reverse the contents of the individual between the indices
-    while start_index < end_index - 1:
-        individual[start_index], individual[end_index - 1] = individual[end_index - 1], individual[start_index]
-        start_index += 1
-        end_index -= 1
+    individual[start_index:end_index] = individual[start_index:end_index][::-1]
 
     return individual,
 

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -196,7 +196,7 @@ def mutInversion(individual):
     end_index = max(index_one, index_two)
 
     # Reverse the contents of the individual between the indices
-    while start_index < end_index:
+    while start_index < end_index - 1:
         individual[start_index], individual[end_index] = individual[end_index], individual[start_index]
         start_index += 1
         end_index -= 1

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -3,6 +3,7 @@ import math
 import random
 
 from itertools import repeat
+from past.builtins import xrange
 
 try:
     from collections.abc import Sequence


### PR DESCRIPTION
Closes #592 

Adds an inversion mutation. See #592. Basically, select two points and reverse the order between the points. It's handy for when adjacency is really important as it ends up being less destructive (if that's what you're looking for). 

Notes:
- It is possible that the indices are the same or adjacent. This scenario is ignored and results in an unmodified individual
- The function was tested locally, but there are no unit test provided. I am not seeing any unit tests for any other genetic operators 
- The `end_point` is **not** selected with `random.randrange(start_index, size)` as that provides a different distribution of selected indices, which is bad. 
- I originally wrote the swapping with slicing, but thought it was too ugly. 