### PR TITLE
:memo: Symbolic Regression Tutorial: Add clarity on eval function values

### DIFF
--- a/doc/examples/gp_symbreg.rst
+++ b/doc/examples/gp_symbreg.rst
@@ -18,7 +18,14 @@ individual's fitness.
 In this example, we use a classical distribution, the quartic polynomial
 :math:`(x^4 + x^3 + x^2 + x)`, a one-dimension distribution. *20* equidistant
 points are generated in the range [-1, 1], and are used to evaluate the
-fitness.
+fitness. 
+
+Note that in this example, the ``evalSymbReg`` function has the polynomial being 
+regressed to hard coded, and thus the :math:`y` value can be calculated for each value of :math:`x`. If one were using the system to fit other data, the hard coded quadratic
+polynomial expression would need to be replaced. For example, 
+:math:`\frac{1}{n}\sum_{i=1}^{n}(\hat{y_{i}} - y_{i})^2`, where :math:`\hat{y_{i}}` is 
+a candidate solution's predicted value based on the dependent variables, and 
+:math:`y_{i}` is the the expected value. 
 
 
 Creating the primitives set

--- a/doc/examples/gp_symbreg.rst
+++ b/doc/examples/gp_symbreg.rst
@@ -21,8 +21,9 @@ points are generated in the range [-1, 1], and are used to evaluate the
 fitness. 
 
 Note that in this example, the ``evalSymbReg`` function has the polynomial being 
-regressed to hard coded, and thus the :math:`y` value can be calculated for each value of :math:`x`. If one were using the system to fit other data, the hard coded quadratic
-polynomial expression would need to be replaced. For example, 
+regressed to hard coded, and thus the :math:`y` value can be calculated for each
+value of :math:`x`. If one were using the system to fit other data, the hard coded
+quadratic polynomial expression would need to be replaced. For example,
 :math:`\frac{1}{n}\sum_{i=1}^{n}(\hat{y_{i}} - y_{i})^2`, where :math:`\hat{y_{i}}` is 
 a candidate solution's predicted value based on the independent variables, and 
 :math:`y_{i}` is the the expected value. 

--- a/doc/examples/gp_symbreg.rst
+++ b/doc/examples/gp_symbreg.rst
@@ -24,7 +24,7 @@ Note that in this example, the ``evalSymbReg`` function has the polynomial being
 regressed to hard coded, and thus the :math:`y` value can be calculated for each value of :math:`x`. If one were using the system to fit other data, the hard coded quadratic
 polynomial expression would need to be replaced. For example, 
 :math:`\frac{1}{n}\sum_{i=1}^{n}(\hat{y_{i}} - y_{i})^2`, where :math:`\hat{y_{i}}` is 
-a candidate solution's predicted value based on the dependent variables, and 
+a candidate solution's predicted value based on the independent variables, and 
 :math:`y_{i}` is the the expected value. 
 
 


### PR DESCRIPTION
Adding more detail on how the evaluation function works and what one would replace the hard coded function with. The point that is trying to be communicated is that the polynomial is used to calculate y^ on the fly. If someone had arbitrary data for the dependent and independent variables, they would use these values instead. 

These details are added based on my observation of where my class is misunderstanding how to use GP for symbolic regression. 

