### PR TITLE
Escape \ in latex_preamble

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -237,7 +237,7 @@ latex_documents = [
 #latex_use_parts = False
 
 # Additional stuff for the LaTeX preamble.
-latex_preamble = '\usepackage{amsmath,amssymb}'
+latex_preamble = r'\usepackage{amsmath,amssymb}'
 
 # Documents to append as an appendix to all manuals.
 #latex_appendices = []


### PR DESCRIPTION
Running with Sphinx under Python 3 was crashing with:
> There is a syntax error in your configuration file: (unicode error) 'unicodeescape' codec can't decode bytes in position 0-1: truncated \uXXXX escape (conf.py, line 246)