### PR TITLE
fixed extra x^2 in docstring of rastrigin_scaled

### DIFF
--- a/deap/benchmarks/__init__.py
+++ b/deap/benchmarks/__init__.py
@@ -243,7 +243,7 @@ def rastrigin_scaled(individual):
     """Scaled Rastrigin test objective function.
 
     :math:`f_{\\text{RastScaled}}(\mathbf{x}) = 10N + \sum_{i=1}^N \
-        \left(10^{\left(\\frac{i-1}{N-1}\\right)} x_i \\right)^2 x_i)^2 - \
+        \left(10^{\left(\\frac{i-1}{N-1}\\right)} x_i \\right)^2 - \
         10\cos\\left(2\\pi 10^{\left(\\frac{i-1}{N-1}\\right)} x_i \\right)`
     """
     N = len(individual)


### PR DESCRIPTION
This is a minor fix which rectifies a typo in the docstring for `deap.benchmarks.rastrigin_scaled`. On the website, note the extra x^2 in the formatted equation:
![image](https://user-images.githubusercontent.com/37961031/148003833-a4f9144b-6332-485d-973b-bd6bf4eec76d.png)
