### PR TITLE
fixed typo in docstring of rastrigin_skew benchmark function

### DIFF
--- a/deap/benchmarks/__init__.py
+++ b/deap/benchmarks/__init__.py
@@ -253,7 +253,7 @@ def rastrigin_scaled(individual):
 def rastrigin_skew(individual):
     """Skewed Rastrigin test objective function.
 
-     :math:`f_{\\text{RastSkew}}(\mathbf{x}) = 10N \sum_{i=1}^N \left(y_i^2 - 10 \\cos(2\\pi x_i)\\right)`
+     :math:`f_{\\text{RastSkew}}(\mathbf{x}) = 10N + \sum_{i=1}^N \left(y_i^2 - 10 \\cos(2\\pi x_i)\\right)`
 
      :math:`\\text{with } y_i = \
                             \\begin{cases} \


### PR DESCRIPTION
Minor fix where an addition sign is missing in the formatted equation written in the docstring. 
![image](https://user-images.githubusercontent.com/37961031/148147397-208d2534-e085-4805-bce6-1289bdc1435d.png)
