### PR TITLE
2to3

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ DEAP build status is available on Travis-CI https://travis-ci.org/DEAP/deap.
 ## Requirements
 The most basic features of DEAP requires Python2.6. In order to combine the toolbox and the multiprocessing module Python2.7 is needed for its support to pickle partial functions. CMA-ES requires Numpy, and we recommend matplotlib for visualization of results as it is fully compatible with DEAP's API.
 
-Since version 0.8, DEAP is compatible out of the box with Python 3. The installation procedure automatically translates the source to Python 3 with 2to3.
+Since version 0.8, DEAP is compatible out of the box with Python 3.
 
 ## Example
 

--- a/deap/algorithms.py
+++ b/deap/algorithms.py
@@ -157,7 +157,7 @@ def eaSimple(population, toolbox, cxpb, mutpb, ngen, stats=None,
     record = stats.compile(population) if stats else {}
     logbook.record(gen=0, nevals=len(invalid_ind), **record)
     if verbose:
-        print logbook.stream
+        print(logbook.stream)
 
     # Begin the generational process
     for gen in range(1, ngen + 1):
@@ -184,7 +184,7 @@ def eaSimple(population, toolbox, cxpb, mutpb, ngen, stats=None,
         record = stats.compile(population) if stats else {}
         logbook.record(gen=gen, nevals=len(invalid_ind), **record)
         if verbose:
-            print logbook.stream
+            print(logbook.stream)
 
     return population, logbook
 
@@ -308,7 +308,7 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen,
     record = stats.compile(population) if stats is not None else {}
     logbook.record(gen=0, nevals=len(invalid_ind), **record)
     if verbose:
-        print logbook.stream
+        print(logbook.stream)
 
     # Begin the generational process
     for gen in range(1, ngen + 1):
@@ -332,7 +332,7 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen,
         record = stats.compile(population) if stats is not None else {}
         logbook.record(gen=gen, nevals=len(invalid_ind), **record)
         if verbose:
-            print logbook.stream
+            print(logbook.stream)
 
     return population, logbook
 
@@ -409,7 +409,7 @@ def eaMuCommaLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen,
     record = stats.compile(population) if stats is not None else {}
     logbook.record(gen=0, nevals=len(invalid_ind), **record)
     if verbose:
-        print logbook.stream
+        print(logbook.stream)
 
     # Begin the generational process
     for gen in range(1, ngen + 1):
@@ -433,7 +433,7 @@ def eaMuCommaLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen,
         record = stats.compile(population) if stats is not None else {}
         logbook.record(gen=gen, nevals=len(invalid_ind), **record)
         if verbose:
-            print logbook.stream
+            print(logbook.stream)
     return population, logbook
 
 
@@ -498,6 +498,6 @@ def eaGenerateUpdate(toolbox, ngen, halloffame=None, stats=None,
         record = stats.compile(population) if stats is not None else {}
         logbook.record(gen=gen, nevals=len(population), **record)
         if verbose:
-            print logbook.stream
+            print(logbook.stream)
 
     return population, logbook

--- a/deap/algorithms.py
+++ b/deap/algorithms.py
@@ -230,7 +230,7 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
     for _ in range(lambda_):
         op_choice = random.random()
         if op_choice < cxpb:            # Apply crossover
-            ind1, ind2 = map(toolbox.clone, random.sample(population, 2))
+            ind1, ind2 = list(map(toolbox.clone, random.sample(population, 2)))
             ind1, ind2 = toolbox.mate(ind1, ind2)
             del ind1.fitness.values
             offspring.append(ind1)

--- a/deap/algorithms.py
+++ b/deap/algorithms.py
@@ -227,7 +227,7 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
         "or equal to 1.0.")
 
     offspring = []
-    for _ in xrange(lambda_):
+    for _ in range(lambda_):
         op_choice = random.random()
         if op_choice < cxpb:            # Apply crossover
             ind1, ind2 = map(toolbox.clone, random.sample(population, 2))
@@ -481,7 +481,7 @@ def eaGenerateUpdate(toolbox, ngen, halloffame=None, stats=None,
     logbook = tools.Logbook()
     logbook.header = ['gen', 'nevals'] + (stats.fields if stats else [])
 
-    for gen in xrange(ngen):
+    for gen in range(ngen):
         # Generate a new population
         population = toolbox.generate()
         # Evaluate the individuals

--- a/deap/algorithms.py
+++ b/deap/algorithms.py
@@ -27,7 +27,7 @@ you really want them to do.
 
 import random
 
-import tools
+from . import tools
 
 
 def varAnd(population, toolbox, cxpb, mutpb):

--- a/deap/base.py
+++ b/deap/base.py
@@ -190,12 +190,12 @@ class Fitness(object):
             self.wvalues = tuple(map(mul, values, self.weights))
         except TypeError:
             _, _, traceback = sys.exc_info()
-            raise TypeError, ("Both weights and assigned values must be a "
+            raise TypeError("Both weights and assigned values must be a "
                               "sequence of numbers when assigning to values of "
                               "%r. Currently assigning value(s) %r of %r to a "
                               "fitness with weights %s."
                               % (self.__class__, values, type(values),
-                                 self.weights)), traceback
+                                 self.weights)).with_traceback(traceback)
 
     def delValues(self):
         self.wvalues = ()

--- a/deap/benchmarks/__init__.py
+++ b/deap/benchmarks/__init__.py
@@ -489,7 +489,7 @@ def dtlz1(individual, obj):
     """
     g = 100 * (len(individual[obj-1:]) + sum((xi-0.5)**2 - cos(20*pi*(xi-0.5)) for xi in individual[obj-1:]))
     f = [0.5 * reduce(mul, individual[:obj-1], 1) * (1 + g)]
-    f.extend(0.5 * reduce(mul, individual[:m], 1) * (1 - individual[m]) * (1 + g) for m in reversed(xrange(obj-1)))
+    f.extend(0.5 * reduce(mul, individual[:m], 1) * (1 - individual[m]) * (1 + g) for m in reversed(range(obj-1)))
     return f
 
 def dtlz2(individual, obj):

--- a/deap/benchmarks/__init__.py
+++ b/deap/benchmarks/__init__.py
@@ -24,9 +24,9 @@ from functools import reduce
 
 # Unimodal
 def rand(individual):
-    """Random test objective function.
+    r"""Random test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -37,14 +37,14 @@ def rand(individual):
        * - Global optima
          - none
        * - Function
-         - :math:`f(\mathbf{x}) = \\text{\\texttt{random}}(0,1)`
+         - :math:`f(\mathbf{x}) = \text{\texttt{random}}(0,1)`
     """
     return random.random(),
 
 def plane(individual):
-    """Plane test objective function.
+    r"""Plane test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -53,16 +53,16 @@ def plane(individual):
        * - Range
          - none
        * - Global optima
-         - :math:`x_i = 0, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 0, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
          - :math:`f(\mathbf{x}) = x_0`
     """
     return individual[0],
 
 def sphere(individual):
-    """Sphere test objective function.
+    r"""Sphere test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -71,16 +71,16 @@ def sphere(individual):
        * - Range
          - none
        * - Global optima
-         - :math:`x_i = 0, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 0, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
          - :math:`f(\mathbf{x}) = \sum_{i=1}^Nx_i^2`
     """
     return sum(gene * gene for gene in individual),
 
 def cigar(individual):
-    """Cigar test objective function.
+    r"""Cigar test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -89,16 +89,16 @@ def cigar(individual):
        * - Range
          - none
        * - Global optima
-         - :math:`x_i = 0, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 0, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
-         - :math:`f(\mathbf{x}) = x_0^2 + 10^6\\sum_{i=1}^N\,x_i^2`
+         - :math:`f(\mathbf{x}) = x_0^2 + 10^6\sum_{i=1}^N\,x_i^2`
     """
     return individual[0]**2 + 1e6 * sum(gene * gene for gene in individual[1:]),
 
-def rosenbrock(individual):  
-    """Rosenbrock test objective function.
+def rosenbrock(individual):
+    r"""Rosenbrock test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -107,9 +107,9 @@ def rosenbrock(individual):
        * - Range
          - none
        * - Global optima
-         - :math:`x_i = 1, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 1, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
-         - :math:`f(\\mathbf{x}) = \\sum_{i=1}^{N-1} (1-x_i)^2 + 100 (x_{i+1} - x_i^2 )^2`
+         - :math:`f(\mathbf{x}) = \sum_{i=1}^{N-1} (1-x_i)^2 + 100 (x_{i+1} - x_i^2 )^2`
 
     .. plot:: code/benchmarks/rosenbrock.py
        :width: 67 %
@@ -118,12 +118,12 @@ def rosenbrock(individual):
                    for x, y in zip(individual[:-1], individual[1:])),
 
 def h1(individual):
-    """ Simple two-dimensional function containing several local maxima.
-    From: The Merits of a Parallel Genetic Algorithm in Solving Hard 
-    Optimization Problems, A. J. Knoek van Soest and L. J. R. Richard 
+    r""" Simple two-dimensional function containing several local maxima.
+    From: The Merits of a Parallel Genetic Algorithm in Solving Hard
+    Optimization Problems, A. J. Knoek van Soest and L. J. R. Richard
     Casius, J. Biomech. Eng. 125, 141 (2003)
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -134,8 +134,8 @@ def h1(individual):
        * - Global optima
          - :math:`\mathbf{x} = (8.6998, 6.7665)`, :math:`f(\mathbf{x}) = 2`\n
        * - Function
-         - :math:`f(\mathbf{x}) = \\frac{\sin(x_1 - \\frac{x_2}{8})^2 + \
-            \\sin(x_2 + \\frac{x_1}{8})^2}{\\sqrt{(x_1 - 8.6998)^2 + \
+         - :math:`f(\mathbf{x}) = \frac{\sin(x_1 - \frac{x_2}{8})^2 + \
+            \sin(x_2 + \frac{x_1}{8})^2}{\sqrt{(x_1 - 8.6998)^2 + \
             (x_2 - 6.7665)^2} + 1}`
 
     .. plot:: code/benchmarks/h1.py
@@ -145,12 +145,12 @@ def h1(individual):
     denum = ((individual[0] - 8.6998)**2 + (individual[1] - 6.7665)**2)**0.5 + 1
     return num / denum,
 
- # 
+ #
 # Multimodal
 def ackley(individual):
-    """Ackley test objective function.
+    r"""Ackley test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -159,10 +159,10 @@ def ackley(individual):
        * - Range
          - :math:`x_i \in [-15, 30]`
        * - Global optima
-         - :math:`x_i = 0, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 0, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
-         - :math:`f(\\mathbf{x}) = 20 - 20\exp\left(-0.2\sqrt{\\frac{1}{N} \
-            \\sum_{i=1}^N x_i^2} \\right) + e - \\exp\\left(\\frac{1}{N}\sum_{i=1}^N \\cos(2\pi x_i) \\right)`
+         - :math:`f(\mathbf{x}) = 20 - 20\exp\left(-0.2\sqrt{\frac{1}{N} \
+            \sum_{i=1}^N x_i^2} \right) + e - \exp\left(\frac{1}{N}\sum_{i=1}^N \cos(2\pi x_i) \right)`
 
     .. plot:: code/benchmarks/ackley.py
        :width: 67 %
@@ -172,9 +172,9 @@ def ackley(individual):
             + e - exp(1.0/N * sum(cos(2*pi*x) for x in individual)),
 
 def bohachevsky(individual):
-    """Bohachevsky test objective function.
+    r"""Bohachevsky test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -183,7 +183,7 @@ def bohachevsky(individual):
        * - Range
          - :math:`x_i \in [-100, 100]`
        * - Global optima
-         - :math:`x_i = 0, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 0, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
          -  :math:`f(\mathbf{x}) = \sum_{i=1}^{N-1}(x_i^2 + 2x_{i+1}^2 - \
                    0.3\cos(3\pi x_i) - 0.4\cos(4\pi x_{i+1}) + 0.7)`
@@ -191,13 +191,13 @@ def bohachevsky(individual):
     .. plot:: code/benchmarks/bohachevsky.py
        :width: 67 %
     """
-    return sum(x**2 + 2*x1**2 - 0.3*cos(3*pi*x) - 0.4*cos(4*pi*x1) + 0.7 
+    return sum(x**2 + 2*x1**2 - 0.3*cos(3*pi*x) - 0.4*cos(4*pi*x1) + 0.7
                 for x, x1 in zip(individual[:-1], individual[1:])),
 
 def griewank(individual):
-    """Griewank test objective function.
+    r"""Griewank test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -206,10 +206,10 @@ def griewank(individual):
        * - Range
          - :math:`x_i \in [-600, 600]`
        * - Global optima
-         - :math:`x_i = 0, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 0, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
-         - :math:`f(\\mathbf{x}) = \\frac{1}{4000}\\sum_{i=1}^N\,x_i^2 - \
-                  \prod_{i=1}^N\\cos\\left(\\frac{x_i}{\sqrt{i}}\\right) + 1`
+         - :math:`f(\mathbf{x}) = \frac{1}{4000}\sum_{i=1}^N\,x_i^2 - \
+                  \prod_{i=1}^N\cos\left(\frac{x_i}{\sqrt{i}}\right) + 1`
 
     .. plot:: code/benchmarks/griewank.py
        :width: 67 %
@@ -218,9 +218,9 @@ def griewank(individual):
         reduce(mul, (cos(x/sqrt(i+1.0)) for i, x in enumerate(individual)), 1) + 1,
 
 def rastrigin(individual):
-    """Rastrigin test objective function.
+    r"""Rastrigin test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -229,45 +229,45 @@ def rastrigin(individual):
        * - Range
          - :math:`x_i \in [-5.12, 5.12]`
        * - Global optima
-         - :math:`x_i = 0, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 0, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
-         - :math:`f(\\mathbf{x}) = 10N + \sum_{i=1}^N x_i^2 - 10 \\cos(2\\pi x_i)`
+         - :math:`f(\mathbf{x}) = 10N + \sum_{i=1}^N x_i^2 - 10 \cos(2\pi x_i)`
 
     .. plot:: code/benchmarks/rastrigin.py
        :width: 67 %
-    """     
+    """
     return 10 * len(individual) + sum(gene * gene - 10 * \
                         cos(2 * pi * gene) for gene in individual),
 
 def rastrigin_scaled(individual):
-    """Scaled Rastrigin test objective function.
+    r"""Scaled Rastrigin test objective function.
 
-    :math:`f_{\\text{RastScaled}}(\mathbf{x}) = 10N + \sum_{i=1}^N \
-        \left(10^{\left(\\frac{i-1}{N-1}\\right)} x_i \\right)^2 - \
-        10\cos\\left(2\\pi 10^{\left(\\frac{i-1}{N-1}\\right)} x_i \\right)`
+    :math:`f_{\text{RastScaled}}(\mathbf{x}) = 10N + \sum_{i=1}^N \
+        \left(10^{\left(\frac{i-1}{N-1}\right)} x_i \right)^2 - \
+        10\cos\left(2\pi 10^{\left(\frac{i-1}{N-1}\right)} x_i \right)`
     """
     N = len(individual)
-    return 10*N + sum((10**(i/(N-1))*x)**2 - 
+    return 10*N + sum((10**(i/(N-1))*x)**2 -
                       10*cos(2*pi*10**(i/(N-1))*x) for i, x in enumerate(individual)),
 
 def rastrigin_skew(individual):
-    """Skewed Rastrigin test objective function.
+    r"""Skewed Rastrigin test objective function.
 
-     :math:`f_{\\text{RastSkew}}(\mathbf{x}) = 10N + \sum_{i=1}^N \left(y_i^2 - 10 \\cos(2\\pi x_i)\\right)`
+     :math:`f_{\text{RastSkew}}(\mathbf{x}) = 10N + \sum_{i=1}^N \left(y_i^2 - 10 \cos(2\pi x_i)\right)`
 
-     :math:`\\text{with } y_i = \
-                            \\begin{cases} \
-                                10\\cdot x_i & \\text{ if } x_i > 0,\\\ \
-                                x_i & \\text{ otherwise } \
-                            \\end{cases}`
+     :math:`\text{with } y_i = \
+                            \begin{cases} \
+                                10\cdot x_i & \text{ if } x_i > 0,\\ \
+                                x_i & \text{ otherwise } \
+                            \end{cases}`
     """
     N = len(individual)
-    return 10*N + sum((10*x if x > 0 else x)**2 
+    return 10*N + sum((10*x if x > 0 else x)**2
                     - 10*cos(2*pi*(10*x if x > 0 else x)) for x in individual),
 def schaffer(individual):
-    """Schaffer test objective function.
+    r"""Schaffer test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -276,22 +276,22 @@ def schaffer(individual):
        * - Range
          - :math:`x_i \in [-100, 100]`
        * - Global optima
-         - :math:`x_i = 0, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 0, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
          -  :math:`f(\mathbf{x}) = \sum_{i=1}^{N-1} (x_i^2+x_{i+1}^2)^{0.25} \cdot \
-                  \\left[ \sin^2(50\cdot(x_i^2+x_{i+1}^2)^{0.10}) + 1.0 \
-                  \\right]`
+                  \left[ \sin^2(50\cdot(x_i^2+x_{i+1}^2)^{0.10}) + 1.0 \
+                  \right]`
 
     .. plot:: code/benchmarks/schaffer.py
         :width: 67 %
     """
-    return sum((x**2+x1**2)**0.25 * ((sin(50*(x**2+x1**2)**0.1))**2+1.0) 
+    return sum((x**2+x1**2)**0.25 * ((sin(50*(x**2+x1**2)**0.1))**2+1.0)
                 for x, x1 in zip(individual[:-1], individual[1:])),
 
 def schwefel(individual):
-    """Schwefel test objective function.
+    r"""Schwefel test objective function.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -300,23 +300,23 @@ def schwefel(individual):
        * - Range
          - :math:`x_i \in [-500, 500]`
        * - Global optima
-         - :math:`x_i = 420.96874636, \\forall i \in \\lbrace 1 \\ldots N\\rbrace`, :math:`f(\mathbf{x}) = 0`
+         - :math:`x_i = 420.96874636, \forall i \in \lbrace 1 \ldots N\rbrace`, :math:`f(\mathbf{x}) = 0`
        * - Function
          - :math:`f(\mathbf{x}) = 418.9828872724339\cdot N - \
-            \sum_{i=1}^N\,x_i\sin\\left(\sqrt{|x_i|}\\right)`
+            \sum_{i=1}^N\,x_i\sin\left(\sqrt{|x_i|}\right)`
 
 
     .. plot:: code/benchmarks/schwefel.py
         :width: 67 %
-    """    
+    """
     N = len(individual)
     return 418.9828872724339*N-sum(x*sin(sqrt(abs(x))) for x in individual),
 
 def himmelblau(individual):
-    """The Himmelblau's function is multimodal with 4 defined minimums in 
+    r"""The Himmelblau's function is multimodal with 4 defined minimums in
     :math:`[-6, 6]^2`.
 
-    .. list-table:: 
+    .. list-table::
        :widths: 10 50
        :stub-columns: 1
 
@@ -339,21 +339,21 @@ def himmelblau(individual):
         (individual[0] + individual[1] * individual[1] - 7)**2,
 
 def shekel(individual, a, c):
-    """The Shekel multimodal function can have any number of maxima. The number
+    r"""The Shekel multimodal function can have any number of maxima. The number
     of maxima is given by the length of any of the arguments *a* or *c*, *a*
-    is a matrix of size :math:`M\\times N`, where *M* is the number of maxima
-    and *N* the number of dimensions and *c* is a :math:`M\\times 1` vector.
+    is a matrix of size :math:`M\times N`, where *M* is the number of maxima
+    and *N* the number of dimensions and *c* is a :math:`M\times 1` vector.
 
-    :math:`f_\\text{Shekel}(\mathbf{x}) = \\sum_{i = 1}^{M} \\frac{1}{c_{i} + 
-    \\sum_{j = 1}^{N} (x_{j} - a_{ij})^2 }`
+    :math:`f_\text{Shekel}(\mathbf{x}) = \sum_{i = 1}^{M} \frac{1}{c_{i} +
+    \sum_{j = 1}^{N} (x_{j} - a_{ij})^2 }`
 
     The following figure uses
 
-    :math:`\\mathcal{A} = \\begin{bmatrix} 0.5 & 0.5 \\\\ 0.25 & 0.25 \\\\ 
-    0.25 & 0.75 \\\\ 0.75 & 0.25 \\\\ 0.75 & 0.75 \\end{bmatrix}` and
-    :math:`\\mathbf{c} = \\begin{bmatrix} 0.002 \\\\ 0.005 \\\\ 0.005
-    \\\\ 0.005 \\\\ 0.005 \\end{bmatrix}`, thus defining 5 maximums in
-    :math:`\\mathbb{R}^2`.
+    :math:`\mathcal{A} = \begin{bmatrix} 0.5 & 0.5 \\ 0.25 & 0.25 \\
+    0.25 & 0.75 \\ 0.75 & 0.25 \\ 0.75 & 0.75 \end{bmatrix}` and
+    :math:`\mathbf{c} = \begin{bmatrix} 0.002 \\ 0.005 \\ 0.005
+    \\ 0.005 \\ 0.005 \end{bmatrix}`, thus defining 5 maximums in
+    :math:`\mathbb{R}^2`.
 
     .. plot:: code/benchmarks/shekel.py
         :width: 67 %
@@ -362,11 +362,11 @@ def shekel(individual, a, c):
 
 # Multiobjectives
 def kursawe(individual):
-    """Kursawe multiobjective function.
+    r"""Kursawe multiobjective function.
 
-    :math:`f_{\\text{Kursawe}1}(\\mathbf{x}) = \\sum_{i=1}^{N-1} -10 e^{-0.2 \\sqrt{x_i^2 + x_{i+1}^2} }`
+    :math:`f_{\text{Kursawe}1}(\mathbf{x}) = \sum_{i=1}^{N-1} -10 e^{-0.2 \sqrt{x_i^2 + x_{i+1}^2} }`
 
-    :math:`f_{\\text{Kursawe}2}(\\mathbf{x}) = \\sum_{i=1}^{N} |x_i|^{0.8} + 5 \\sin(x_i^3)`
+    :math:`f_{\text{Kursawe}2}(\mathbf{x}) = \sum_{i=1}^{N} |x_i|^{0.8} + 5 \sin(x_i^3)`
 
     .. plot:: code/benchmarks/kursawe.py
        :width: 100 %
@@ -377,25 +377,25 @@ def kursawe(individual):
 
 
 def schaffer_mo(individual):
-    """Schaffer's multiobjective function on a one attribute *individual*.
+    r"""Schaffer's multiobjective function on a one attribute *individual*.
     From: J. D. Schaffer, "Multiple objective optimization with vector
     evaluated genetic algorithms", in Proceedings of the First International
-    Conference on Genetic Algorithms, 1987. 
+    Conference on Genetic Algorithms, 1987.
 
-    :math:`f_{\\text{Schaffer}1}(\\mathbf{x}) = x_1^2`
+    :math:`f_{\text{Schaffer}1}(\mathbf{x}) = x_1^2`
 
-    :math:`f_{\\text{Schaffer}2}(\\mathbf{x}) = (x_1-2)^2`
+    :math:`f_{\text{Schaffer}2}(\mathbf{x}) = (x_1-2)^2`
     """
     return individual[0] ** 2, (individual[0] - 2) ** 2
 
 def zdt1(individual):
-    """ZDT1 multiobjective function.
+    r"""ZDT1 multiobjective function.
 
-    :math:`g(\\mathbf{x}) = 1 + \\frac{9}{n-1}\\sum_{i=2}^n x_i`
+    :math:`g(\mathbf{x}) = 1 + \frac{9}{n-1}\sum_{i=2}^n x_i`
 
-    :math:`f_{\\text{ZDT1}1}(\\mathbf{x}) = x_1`
+    :math:`f_{\text{ZDT1}1}(\mathbf{x}) = x_1`
 
-    :math:`f_{\\text{ZDT1}2}(\\mathbf{x}) = g(\\mathbf{x})\\left[1 - \\sqrt{\\frac{x_1}{g(\\mathbf{x})}}\\right]`
+    :math:`f_{\text{ZDT1}2}(\mathbf{x}) = g(\mathbf{x})\left[1 - \sqrt{\frac{x_1}{g(\mathbf{x})}}\right]`
     """
     g  = 1.0 + 9.0*sum(individual[1:])/(len(individual)-1)
     f1 = individual[0]
@@ -403,13 +403,13 @@ def zdt1(individual):
     return f1, f2
 
 def zdt2(individual):
-    """ZDT2 multiobjective function.
+    r"""ZDT2 multiobjective function.
 
-    :math:`g(\\mathbf{x}) = 1 + \\frac{9}{n-1}\\sum_{i=2}^n x_i`
+    :math:`g(\mathbf{x}) = 1 + \frac{9}{n-1}\sum_{i=2}^n x_i`
 
-    :math:`f_{\\text{ZDT2}1}(\\mathbf{x}) = x_1`
+    :math:`f_{\text{ZDT2}1}(\mathbf{x}) = x_1`
 
-    :math:`f_{\\text{ZDT2}2}(\\mathbf{x}) = g(\\mathbf{x})\\left[1 - \\left(\\frac{x_1}{g(\\mathbf{x})}\\right)^2\\right]`
+    :math:`f_{\text{ZDT2}2}(\mathbf{x}) = g(\mathbf{x})\left[1 - \left(\frac{x_1}{g(\mathbf{x})}\right)^2\right]`
 
     """
 
@@ -419,13 +419,13 @@ def zdt2(individual):
     return f1, f2
 
 def zdt3(individual):
-    """ZDT3 multiobjective function.
+    r"""ZDT3 multiobjective function.
 
-    :math:`g(\\mathbf{x}) = 1 + \\frac{9}{n-1}\\sum_{i=2}^n x_i`
+    :math:`g(\mathbf{x}) = 1 + \frac{9}{n-1}\sum_{i=2}^n x_i`
 
-    :math:`f_{\\text{ZDT3}1}(\\mathbf{x}) = x_1`
+    :math:`f_{\text{ZDT3}1}(\mathbf{x}) = x_1`
 
-    :math:`f_{\\text{ZDT3}2}(\\mathbf{x}) = g(\\mathbf{x})\\left[1 - \\sqrt{\\frac{x_1}{g(\\mathbf{x})}} - \\frac{x_1}{g(\\mathbf{x})}\\sin(10\\pi x_1)\\right]`
+    :math:`f_{\text{ZDT3}2}(\mathbf{x}) = g(\mathbf{x})\left[1 - \sqrt{\frac{x_1}{g(\mathbf{x})}} - \frac{x_1}{g(\mathbf{x})}\sin(10\pi x_1)\right]`
 
     """
 
@@ -435,13 +435,13 @@ def zdt3(individual):
     return f1, f2
 
 def zdt4(individual):
-    """ZDT4 multiobjective function.
+    r"""ZDT4 multiobjective function.
 
-    :math:`g(\\mathbf{x}) = 1 + 10(n-1) + \\sum_{i=2}^n \\left[ x_i^2 - 10\\cos(4\\pi x_i) \\right]`
+    :math:`g(\mathbf{x}) = 1 + 10(n-1) + \sum_{i=2}^n \left[ x_i^2 - 10\cos(4\pi x_i) \right]`
 
-    :math:`f_{\\text{ZDT4}1}(\\mathbf{x}) = x_1`
+    :math:`f_{\text{ZDT4}1}(\mathbf{x}) = x_1`
 
-    :math:`f_{\\text{ZDT4}2}(\\mathbf{x}) = g(\\mathbf{x})\\left[ 1 - \\sqrt{x_1/g(\\mathbf{x})} \\right]`
+    :math:`f_{\text{ZDT4}2}(\mathbf{x}) = g(\mathbf{x})\left[ 1 - \sqrt{x_1/g(\mathbf{x})} \right]`
 
     """
     g  = 1 + 10*(len(individual)-1) + sum(xi**2 - 10*cos(4*pi*xi) for xi in individual[1:])
@@ -450,13 +450,13 @@ def zdt4(individual):
     return f1, f2
 
 def zdt6(individual):
-    """ZDT6 multiobjective function.
+    r"""ZDT6 multiobjective function.
 
-    :math:`g(\\mathbf{x}) = 1 + 9 \\left[ \\left(\\sum_{i=2}^n x_i\\right)/(n-1) \\right]^{0.25}`
+    :math:`g(\mathbf{x}) = 1 + 9 \left[ \left(\sum_{i=2}^n x_i\right)/(n-1) \right]^{0.25}`
 
-    :math:`f_{\\text{ZDT6}1}(\\mathbf{x}) = 1 - \\exp(-4x_1)\\sin^6(6\\pi x_1)`
+    :math:`f_{\text{ZDT6}1}(\mathbf{x}) = 1 - \exp(-4x_1)\sin^6(6\pi x_1)`
 
-    :math:`f_{\\text{ZDT6}2}(\\mathbf{x}) = g(\\mathbf{x}) \left[ 1 - (f_{\\text{ZDT6}1}(\\mathbf{x})/g(\\mathbf{x}))^2 \\right]`
+    :math:`f_{\text{ZDT6}2}(\mathbf{x}) = g(\mathbf{x}) \left[ 1 - (f_{\text{ZDT6}1}(\mathbf{x})/g(\mathbf{x}))^2 \right]`
 
     """
     g  = 1 + 9 * (sum(individual[1:]) / (len(individual)-1))**0.25
@@ -465,25 +465,25 @@ def zdt6(individual):
     return f1, f2
 
 def dtlz1(individual, obj):
-    """DTLZ1 multiobjective function. It returns a tuple of *obj* values. 
+    r"""DTLZ1 multiobjective function. It returns a tuple of *obj* values.
     The individual must have at least *obj* elements.
-    From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective 
+    From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective
     Optimization Test Problems. CEC 2002, p. 825 - 830, IEEE Press, 2002.
 
-    :math:`g(\\mathbf{x}_m) = 100\\left(|\\mathbf{x}_m| + \sum_{x_i \in \\mathbf{x}_m}\\left((x_i - 0.5)^2 - \\cos(20\pi(x_i - 0.5))\\right)\\right)`
+    :math:`g(\mathbf{x}_m) = 100\left(|\mathbf{x}_m| + \sum_{x_i \in \mathbf{x}_m}\left((x_i - 0.5)^2 - \cos(20\pi(x_i - 0.5))\right)\right)`
 
-    :math:`f_{\\text{DTLZ1}1}(\\mathbf{x}) = \\frac{1}{2} (1 + g(\\mathbf{x}_m)) \\prod_{i=1}^{m-1}x_i`
+    :math:`f_{\text{DTLZ1}1}(\mathbf{x}) = \frac{1}{2} (1 + g(\mathbf{x}_m)) \prod_{i=1}^{m-1}x_i`
 
-    :math:`f_{\\text{DTLZ1}2}(\\mathbf{x}) = \\frac{1}{2} (1 + g(\\mathbf{x}_m)) (1-x_{m-1}) \\prod_{i=1}^{m-2}x_i`
+    :math:`f_{\text{DTLZ1}2}(\mathbf{x}) = \frac{1}{2} (1 + g(\mathbf{x}_m)) (1-x_{m-1}) \prod_{i=1}^{m-2}x_i`
 
-    :math:`\\ldots`
+    :math:`\ldots`
 
-    :math:`f_{\\text{DTLZ1}m-1}(\\mathbf{x}) = \\frac{1}{2} (1 + g(\\mathbf{x}_m)) (1 - x_2) x_1`
+    :math:`f_{\text{DTLZ1}m-1}(\mathbf{x}) = \frac{1}{2} (1 + g(\mathbf{x}_m)) (1 - x_2) x_1`
 
-    :math:`f_{\\text{DTLZ1}m}(\\mathbf{x}) = \\frac{1}{2} (1 - x_1)(1 + g(\\mathbf{x}_m))`
+    :math:`f_{\text{DTLZ1}m}(\mathbf{x}) = \frac{1}{2} (1 - x_1)(1 + g(\mathbf{x}_m))`
 
-    Where :math:`m` is the number of objectives and :math:`\\mathbf{x}_m` is a
-    vector of the remaining attributes :math:`[x_m~\\ldots~x_n]` of the
+    Where :math:`m` is the number of objectives and :math:`\mathbf{x}_m` is a
+    vector of the remaining attributes :math:`[x_m~\ldots~x_n]` of the
     individual in :math:`n > m` dimensions.
 
     """
@@ -493,23 +493,23 @@ def dtlz1(individual, obj):
     return f
 
 def dtlz2(individual, obj):
-    """DTLZ2 multiobjective function. It returns a tuple of *obj* values. 
+    r"""DTLZ2 multiobjective function. It returns a tuple of *obj* values.
     The individual must have at least *obj* elements.
-    From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective 
+    From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective
     Optimization Test Problems. CEC 2002, p. 825 - 830, IEEE Press, 2002.
 
-    :math:`g(\\mathbf{x}_m) = \\sum_{x_i \in \\mathbf{x}_m} (x_i - 0.5)^2`
+    :math:`g(\mathbf{x}_m) = \sum_{x_i \in \mathbf{x}_m} (x_i - 0.5)^2`
 
-    :math:`f_{\\text{DTLZ2}1}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\prod_{i=1}^{m-1} \\cos(0.5x_i\pi)`
+    :math:`f_{\text{DTLZ2}1}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \prod_{i=1}^{m-1} \cos(0.5x_i\pi)`
 
-    :math:`f_{\\text{DTLZ2}2}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\sin(0.5x_{m-1}\pi ) \\prod_{i=1}^{m-2} \\cos(0.5x_i\pi)`
+    :math:`f_{\text{DTLZ2}2}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \sin(0.5x_{m-1}\pi ) \prod_{i=1}^{m-2} \cos(0.5x_i\pi)`
 
-    :math:`\\ldots`
+    :math:`\ldots`
 
-    :math:`f_{\\text{DTLZ2}m}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\sin(0.5x_{1}\pi )`
+    :math:`f_{\text{DTLZ2}m}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \sin(0.5x_{1}\pi )`
 
-    Where :math:`m` is the number of objectives and :math:`\\mathbf{x}_m` is a
-    vector of the remaining attributes :math:`[x_m~\\ldots~x_n]` of the
+    Where :math:`m` is the number of objectives and :math:`\mathbf{x}_m` is a
+    vector of the remaining attributes :math:`[x_m~\ldots~x_n]` of the
     individual in :math:`n > m` dimensions.
     """
     xc = individual[:obj-1]
@@ -521,23 +521,23 @@ def dtlz2(individual, obj):
     return f
 
 def dtlz3(individual, obj):
-    """DTLZ3 multiobjective function. It returns a tuple of *obj* values. 
+    r"""DTLZ3 multiobjective function. It returns a tuple of *obj* values.
     The individual must have at least *obj* elements.
-    From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective 
+    From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective
     Optimization Test Problems. CEC 2002, p. 825 - 830, IEEE Press, 2002.
 
-    :math:`g(\\mathbf{x}_m) = 100\\left(|\\mathbf{x}_m| + \sum_{x_i \in \\mathbf{x}_m}\\left((x_i - 0.5)^2 - \\cos(20\pi(x_i - 0.5))\\right)\\right)`
+    :math:`g(\mathbf{x}_m) = 100\left(|\mathbf{x}_m| + \sum_{x_i \in \mathbf{x}_m}\left((x_i - 0.5)^2 - \cos(20\pi(x_i - 0.5))\right)\right)`
 
-    :math:`f_{\\text{DTLZ3}1}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\prod_{i=1}^{m-1} \\cos(0.5x_i\pi)`
+    :math:`f_{\text{DTLZ3}1}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \prod_{i=1}^{m-1} \cos(0.5x_i\pi)`
 
-    :math:`f_{\\text{DTLZ3}2}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\sin(0.5x_{m-1}\pi ) \\prod_{i=1}^{m-2} \\cos(0.5x_i\pi)`
+    :math:`f_{\text{DTLZ3}2}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \sin(0.5x_{m-1}\pi ) \prod_{i=1}^{m-2} \cos(0.5x_i\pi)`
 
-    :math:`\\ldots`
+    :math:`\ldots`
 
-    :math:`f_{\\text{DTLZ3}m}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\sin(0.5x_{1}\pi )`
+    :math:`f_{\text{DTLZ3}m}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \sin(0.5x_{1}\pi )`
 
-    Where :math:`m` is the number of objectives and :math:`\\mathbf{x}_m` is a
-    vector of the remaining attributes :math:`[x_m~\\ldots~x_n]` of the
+    Where :math:`m` is the number of objectives and :math:`\mathbf{x}_m` is a
+    vector of the remaining attributes :math:`[x_m~\ldots~x_n]` of the
     individual in :math:`n > m` dimensions.
     """
     xc = individual[:obj-1]
@@ -548,25 +548,25 @@ def dtlz3(individual, obj):
     return f
 
 def dtlz4(individual, obj, alpha):
-    """DTLZ4 multiobjective function. It returns a tuple of *obj* values. The
+    r"""DTLZ4 multiobjective function. It returns a tuple of *obj* values. The
     individual must have at least *obj* elements. The *alpha* parameter allows
-    for a meta-variable mapping in :func:`dtlz2` :math:`x_i \\rightarrow
-    x_i^\\alpha`, the authors suggest :math:`\\alpha = 100`.
-    From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective 
+    for a meta-variable mapping in :func:`dtlz2` :math:`x_i \rightarrow
+    x_i^\alpha`, the authors suggest :math:`\alpha = 100`.
+    From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective
     Optimization Test Problems. CEC 2002, p. 825 - 830, IEEE Press, 2002.
 
-    :math:`g(\\mathbf{x}_m) = \\sum_{x_i \in \\mathbf{x}_m} (x_i - 0.5)^2`
+    :math:`g(\mathbf{x}_m) = \sum_{x_i \in \mathbf{x}_m} (x_i - 0.5)^2`
 
-    :math:`f_{\\text{DTLZ4}1}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\prod_{i=1}^{m-1} \\cos(0.5x_i^\\alpha\pi)`
+    :math:`f_{\text{DTLZ4}1}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \prod_{i=1}^{m-1} \cos(0.5x_i^\alpha\pi)`
 
-    :math:`f_{\\text{DTLZ4}2}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\sin(0.5x_{m-1}^\\alpha\pi ) \\prod_{i=1}^{m-2} \\cos(0.5x_i^\\alpha\pi)`
+    :math:`f_{\text{DTLZ4}2}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \sin(0.5x_{m-1}^\alpha\pi ) \prod_{i=1}^{m-2} \cos(0.5x_i^\alpha\pi)`
 
-    :math:`\\ldots`
+    :math:`\ldots`
 
-    :math:`f_{\\text{DTLZ4}m}(\\mathbf{x}) = (1 + g(\\mathbf{x}_m)) \\sin(0.5x_{1}^\\alpha\pi )`
+    :math:`f_{\text{DTLZ4}m}(\mathbf{x}) = (1 + g(\mathbf{x}_m)) \sin(0.5x_{1}^\alpha\pi )`
 
-    Where :math:`m` is the number of objectives and :math:`\\mathbf{x}_m` is a
-    vector of the remaining attributes :math:`[x_m~\\ldots~x_n]` of the
+    Where :math:`m` is the number of objectives and :math:`\mathbf{x}_m` is a
+    vector of the remaining attributes :math:`[x_m~\ldots~x_n]` of the
     individual in :math:`n > m` dimensions.
     """
     xc = individual[:obj-1]
@@ -577,7 +577,7 @@ def dtlz4(individual, obj, alpha):
     return f
 
 def dtlz5(ind, n_objs):
-    """DTLZ5 multiobjective function. It returns a tuple of *obj* values. The
+    r"""DTLZ5 multiobjective function. It returns a tuple of *obj* values. The
     individual must have at least *obj* elements.
     From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective
     Optimization Test Problems. CEC 2002, p. 825-830, IEEE Press, 2002.
@@ -597,7 +597,7 @@ def dtlz5(ind, n_objs):
     return fit
 
 def dtlz6(ind, n_objs):
-    """DTLZ6 multiobjective function. It returns a tuple of *obj* values. The
+    r"""DTLZ6 multiobjective function. It returns a tuple of *obj* values. The
     individual must have at least *obj* elements.
     From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective
     Optimization Test Problems. CEC 2002, p. 825-830, IEEE Press, 2002.
@@ -617,7 +617,7 @@ def dtlz6(ind, n_objs):
     return fit
 
 def dtlz7(ind, n_objs):
-    """DTLZ7 multiobjective function. It returns a tuple of *obj* values. The
+    r"""DTLZ7 multiobjective function. It returns a tuple of *obj* values. The
     individual must have at least *obj* elements.
     From: K. Deb, L. Thiele, M. Laumanns and E. Zitzler. Scalable Multi-Objective
     Optimization Test Problems. CEC 2002, p. 825-830, IEEE Press, 2002.
@@ -628,36 +628,36 @@ def dtlz7(ind, n_objs):
     return fit
 
 def fonseca(individual):
-    """Fonseca and Fleming's multiobjective function.
+    r"""Fonseca and Fleming's multiobjective function.
     From: C. M. Fonseca and P. J. Fleming, "Multiobjective optimization and
     multiple constraint handling with evolutionary algorithms -- Part II:
     Application example", IEEE Transactions on Systems, Man and Cybernetics,
     1998.
 
-    :math:`f_{\\text{Fonseca}1}(\\mathbf{x}) = 1 - e^{-\\sum_{i=1}^{3}(x_i - \\frac{1}{\\sqrt{3}})^2}`
+    :math:`f_{\text{Fonseca}1}(\mathbf{x}) = 1 - e^{-\sum_{i=1}^{3}(x_i - \frac{1}{\sqrt{3}})^2}`
 
-    :math:`f_{\\text{Fonseca}2}(\\mathbf{x}) = 1 - e^{-\\sum_{i=1}^{3}(x_i + \\frac{1}{\\sqrt{3}})^2}`
+    :math:`f_{\text{Fonseca}2}(\mathbf{x}) = 1 - e^{-\sum_{i=1}^{3}(x_i + \frac{1}{\sqrt{3}})^2}`
     """
     f_1 = 1 - exp(-sum((xi - 1/sqrt(3))**2 for xi in individual[:3]))
     f_2 = 1 - exp(-sum((xi + 1/sqrt(3))**2 for xi in individual[:3]))
     return f_1, f_2
 
 def poloni(individual):
-    """Poloni's multiobjective function on a two attribute *individual*. From:
+    r"""Poloni's multiobjective function on a two attribute *individual*. From:
     C. Poloni, "Hybrid GA for multi objective aerodynamic shape optimization",
     in Genetic Algorithms in Engineering and Computer Science, 1997.
 
-    :math:`A_1 = 0.5 \\sin (1) - 2 \\cos (1) + \\sin (2) - 1.5 \\cos (2)`
+    :math:`A_1 = 0.5 \sin (1) - 2 \cos (1) + \sin (2) - 1.5 \cos (2)`
 
-    :math:`A_2 = 1.5 \\sin (1) - \\cos (1) + 2 \\sin (2) - 0.5 \\cos (2)`
+    :math:`A_2 = 1.5 \sin (1) - \cos (1) + 2 \sin (2) - 0.5 \cos (2)`
 
-    :math:`B_1 = 0.5 \\sin (x_1) - 2 \\cos (x_1) + \\sin (x_2) - 1.5 \\cos (x_2)`
+    :math:`B_1 = 0.5 \sin (x_1) - 2 \cos (x_1) + \sin (x_2) - 1.5 \cos (x_2)`
 
-    :math:`B_2 = 1.5 \\sin (x_1) - cos(x_1) + 2 \\sin (x_2) - 0.5 \\cos (x_2)`
+    :math:`B_2 = 1.5 \sin (x_1) - cos(x_1) + 2 \sin (x_2) - 0.5 \cos (x_2)`
 
-    :math:`f_{\\text{Poloni}1}(\\mathbf{x}) = 1 + (A_1 - B_1)^2 + (A_2 - B_2)^2`
+    :math:`f_{\text{Poloni}1}(\mathbf{x}) = 1 + (A_1 - B_1)^2 + (A_2 - B_2)^2`
 
-    :math:`f_{\\text{Poloni}2}(\\mathbf{x}) = (x_1 + 3)^2 + (x_2 + 1)^2`
+    :math:`f_{\text{Poloni}2}(\mathbf{x}) = (x_1 + 3)^2 + (x_2 + 1)^2`
     """
     x_1 = individual[0]
     x_2 = individual[1]
@@ -668,7 +668,7 @@ def poloni(individual):
     return 1 + (A_1 - B_1)**2 + (A_2 - B_2)**2, (x_1 + 3)**2 + (x_2 + 1)**2
 
 def dent(individual, lambda_ = 0.85):
-    """Test problem Dent. Two-objective problem with a "dent". *individual* has
+    r"""Test problem Dent. Two-objective problem with a "dent". *individual* has
     two attributes that take values in [-1.5, 1.5].
     From: Schuetze, O., Laumanns, M., Tantar, E., Coello Coello, C.A., & Talbi, E.-G. (2010).
     Computing gap free Pareto front approximations with stochastic search algorithms.
@@ -678,11 +678,10 @@ def dent(individual, lambda_ = 0.85):
     K. Witting and M. Hessel von Molo. Private communication, 2006.
     """
     d = lambda_ * exp(-(individual[0] - individual[1]) ** 2)
-    f1 = 0.5 * (sqrt(1 + (individual[0] + individual[1]) ** 2) + \
-                sqrt(1 + (individual[0] - individual[1]) ** 2) + \
+    f1 = 0.5 * (sqrt(1 + (individual[0] + individual[1]) ** 2) +
+                sqrt(1 + (individual[0] - individual[1]) ** 2) +
                 individual[0] - individual[1]) + d
-    f2 = 0.5 * (sqrt(1 + (individual[0] + individual[1]) ** 2) + \
-                sqrt(1 + (individual[0] - individual[1]) ** 2) - \
+    f2 = 0.5 * (sqrt(1 + (individual[0] + individual[1]) ** 2) +
+                sqrt(1 + (individual[0] - individual[1]) ** 2) -
                 individual[0] + individual[1]) + d
     return f1, f2
-

--- a/deap/benchmarks/binary.py
+++ b/deap/benchmarks/binary.py
@@ -13,7 +13,6 @@
 #    You should have received a copy of the GNU Lesser General Public
 #    License along with DEAP. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
 from functools import wraps
 import math
 

--- a/deap/benchmarks/binary.py
+++ b/deap/benchmarks/binary.py
@@ -29,7 +29,7 @@ def bin2float(min_, max_, nbits):
             # User must take care to make nelem an integer.
             nelem = len(individual)//nbits
             decoded = [0] * nelem
-            for i in xrange(nelem):
+            for i in range(nelem):
                 gene = int("".join(map(str,
                                        individual[i*nbits:i*nbits+nbits])),
                            2)
@@ -68,10 +68,10 @@ def chuang_f1(individual):
     """
     total = 0
     if individual[-1] == 0:
-        for i in xrange(0, len(individual)-1, 4):
+        for i in range(0, len(individual)-1, 4):
             total += inv_trap(individual[i:i+4])
     else:
-        for i in xrange(0, len(individual)-1, 4):
+        for i in range(0, len(individual)-1, 4):
             total += trap(individual[i:i+4])
     return total,
 
@@ -85,16 +85,16 @@ def chuang_f2(individual):
     """
     total = 0
     if individual[-2] == 0 and individual[-1] == 0:
-        for i in xrange(0, len(individual)-2, 8):
+        for i in range(0, len(individual)-2, 8):
             total += inv_trap(individual[i:i+4]) + inv_trap(individual[i+4:i+8])
     elif individual[-2] == 0 and individual[-1] == 1:
-        for i in xrange(0, len(individual)-2, 8):
+        for i in range(0, len(individual)-2, 8):
             total += inv_trap(individual[i:i+4]) + trap(individual[i+4:i+8])
     elif individual[-2] == 1 and individual[-1] == 0:
-        for i in xrange(0, len(individual)-2, 8):
+        for i in range(0, len(individual)-2, 8):
             total += trap(individual[i:i+4]) + inv_trap(individual[i+4:i+8])
     else:
-        for i in xrange(0, len(individual)-2, 8):
+        for i in range(0, len(individual)-2, 8):
             total += trap(individual[i:i+4]) + trap(individual[i+4:i+8])
     return total,
 
@@ -108,10 +108,10 @@ def chuang_f3(individual):
     """
     total = 0
     if individual[-1] == 0:
-        for i in xrange(0, len(individual)-1, 4):
+        for i in range(0, len(individual)-1, 4):
             total += inv_trap(individual[i:i+4])
     else:
-        for i in xrange(2, len(individual)-3, 4):
+        for i in range(2, len(individual)-3, 4):
             total += inv_trap(individual[i:i+4])
         total += trap(individual[-2:]+individual[:2])
     return total,
@@ -125,7 +125,7 @@ def royal_road1(individual, order):
     nelem = len(individual) // order
     max_value = int(2**order - 1)
     total = 0
-    for i in xrange(nelem):
+    for i in range(nelem):
         value = int("".join(map(str, individual[i*order:i*order+order])), 2)
         total += int(order) * int(value/max_value)
     return total,

--- a/deap/benchmarks/movingpeaks.py
+++ b/deap/benchmarks/movingpeaks.py
@@ -393,6 +393,6 @@ def diversity(population):
 
 if __name__ == "__main__":
     mpb = MovingPeaks(dim=2, npeaks=[1,1,10], number_severity=0.1)
-    print mpb.maximums()
+    print(mpb.maximums())
     mpb.changePeaks()
-    print mpb.maximums()
+    print(mpb.maximums())

--- a/deap/benchmarks/tools.py
+++ b/deap/benchmarks/tools.py
@@ -287,7 +287,7 @@ def convergence(first_front, optimal_front):
         distances.append(float("inf"))
         for opt_ind in optimal_front:
             dist = 0.
-            for i in xrange(len(opt_ind)):
+            for i in range(len(opt_ind)):
                 dist += (ind.fitness.values[i] - opt_ind[i])**2
             if dist < distances[-1]:
                 distances[-1] = dist

--- a/deap/cma.py
+++ b/deap/cma.py
@@ -109,7 +109,7 @@ class Strategy(object):
         self.computeParams(self.params)
 
     def generate(self, ind_init):
-        """Generate a population of :math:`\lambda` individuals of type
+        r"""Generate a population of :math:`\lambda` individuals of type
         *ind_init* from the current strategy.
 
         :param ind_init: A function object that is able to initialize an
@@ -171,7 +171,7 @@ class Strategy(object):
         self.BD = self.B * self.diagD
 
     def computeParams(self, params):
-        """Computes the parameters depending on :math:`\lambda`. It needs to
+        r"""Computes the parameters depending on :math:`\lambda`. It needs to
         be called again if :math:`\lambda` changes during evolution.
 
         :param params: A dictionary of the manually set parameters.
@@ -206,7 +206,7 @@ class Strategy(object):
 
 
 class StrategyOnePlusLambda(object):
-    """
+    r"""
     A CMA-ES strategy that uses the :math:`1 + \lambda` paradigm ([Igel2007]_).
 
     :param parent: An iterable object that indicates where to start the
@@ -257,7 +257,7 @@ class StrategyOnePlusLambda(object):
         self.psucc = self.ptarg
 
     def computeParams(self, params):
-        """Computes the parameters depending on :math:`\lambda`. It needs to
+        r"""Computes the parameters depending on :math:`\lambda`. It needs to
         be called again if :math:`\lambda` changes during evolution.
 
         :param params: A dictionary of the manually set parameters.
@@ -276,7 +276,7 @@ class StrategyOnePlusLambda(object):
         self.pthresh = params.get("pthresh", 0.44)
 
     def generate(self, ind_init):
-        """Generate a population of :math:`\lambda` individuals of type
+        r"""Generate a population of :math:`\lambda` individuals of type
         *ind_init* from the current strategy.
 
         :param ind_init: A function object that is able to initialize an
@@ -392,7 +392,7 @@ class StrategyMultiObjective(object):
         self.indicator = params.get("indicator", tools.hypervolume)
 
     def generate(self, ind_init):
-        """Generate a population of :math:`\lambda` individuals of type
+        r"""Generate a population of :math:`\lambda` individuals of type
         *ind_init* from the current strategy.
 
         :param ind_init: A function object that is able to initialize an

--- a/deap/cma.py
+++ b/deap/cma.py
@@ -24,7 +24,7 @@ import copy
 from math import sqrt, log, exp
 import numpy
 
-import tools
+from . import tools
 
 
 class Strategy(object):

--- a/deap/cma.py
+++ b/deap/cma.py
@@ -118,7 +118,7 @@ class Strategy(object):
         """
         arz = numpy.random.standard_normal((self.lambda_, self.dim))
         arz = self.centroid + self.sigma * numpy.dot(arz, self.BD.T)
-        return map(ind_init, arz)
+        return [ind_init(a) for a in arz]
 
     def update(self, population):
         """Update the current covariance matrix strategy from the
@@ -286,7 +286,7 @@ class StrategyOnePlusLambda(object):
         # self.y = numpy.dot(self.A, numpy.random.standard_normal(self.dim))
         arz = numpy.random.standard_normal((self.lambda_, self.dim))
         arz = self.parent + self.sigma * numpy.dot(arz, self.A.T)
-        return map(ind_init, arz)
+        return [ind_init(a) for a in arz]
 
     def update(self, population):
         """Update the current covariance matrix strategy from the

--- a/deap/creator.py
+++ b/deap/creator.py
@@ -142,7 +142,7 @@ def create(name, base, **kargs):
 
     dict_inst = {}
     dict_cls = {}
-    for obj_name, obj in kargs.iteritems():
+    for obj_name, obj in kargs.items():
         if isinstance(obj, type):
             dict_inst[obj_name] = obj
         else:
@@ -161,7 +161,7 @@ def create(name, base, **kargs):
         """Replace the __init__ function of the new type, in order to
         add attributes that were defined with **kargs to the instance.
         """
-        for obj_name, obj in dict_inst.iteritems():
+        for obj_name, obj in dict_inst.items():
             setattr(self, obj_name, obj())
         if base.__init__ is not object.__init__:
             base.__init__(self, *args, **kargs)

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -1063,7 +1063,7 @@ def harm(population, toolbox, cxpb, mutpb, ngen,
     record = stats.compile(population) if stats else {}
     logbook.record(gen=0, nevals=len(invalid_ind), **record)
     if verbose:
-        print logbook.stream
+        print(logbook.stream)
 
     # Begin the generational process
     for gen in range(1, ngen + 1):
@@ -1130,7 +1130,7 @@ def harm(population, toolbox, cxpb, mutpb, ngen,
         record = stats.compile(population) if stats else {}
         logbook.record(gen=gen, nevals=len(invalid_ind), **record)
         if verbose:
-            print logbook.stream
+            print(logbook.stream)
 
     return population, logbook
 

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -31,7 +31,7 @@ from functools import partial, wraps
 from inspect import isclass
 from operator import eq, lt
 
-import tools  # Needed by HARM-GP
+from . import tools  # Needed by HARM-GP
 
 ######################################
 # GP Data structure                  #

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -480,11 +480,11 @@ def compile(expr, pset):
         return eval(code, pset.context, {})
     except MemoryError:
         _, _, traceback = sys.exc_info()
-        raise MemoryError, ("DEAP : Error in tree evaluation :"
+        raise MemoryError("DEAP : Error in tree evaluation :"
                             " Python cannot evaluate a tree higher than 90. "
                             "To avoid this problem, you should use bloat control on your "
                             "operators. See the DEAP documentation for more information. "
-                            "DEAP will now abort."), traceback
+                            "DEAP will now abort.").with_traceback(traceback)
 
 
 def compileADF(expr, psets):
@@ -618,9 +618,9 @@ def generate(pset, min_, max_, condition, type_=None):
                 term = random.choice(pset.terminals[type_])
             except IndexError:
                 _, _, traceback = sys.exc_info()
-                raise IndexError, "The gp.generate function tried to add " \
-                                  "a terminal of type '%s', but there is " \
-                                  "none available." % (type_,), traceback
+                raise IndexError("The gp.generate function tried to add "
+                                  "a terminal of type '%s', but there is "
+                                  "none available." % (type_,)).with_traceback(traceback)
             if isclass(term):
                 term = term()
             expr.append(term)
@@ -629,9 +629,9 @@ def generate(pset, min_, max_, condition, type_=None):
                 prim = random.choice(pset.primitives[type_])
             except IndexError:
                 _, _, traceback = sys.exc_info()
-                raise IndexError, "The gp.generate function tried to add " \
-                                  "a primitive of type '%s', but there is " \
-                                  "none available." % (type_,), traceback
+                raise IndexError("The gp.generate function tried to add "
+                                  "a primitive of type '%s', but there is "
+                                  "none available." % (type_,)).with_traceback(traceback)
             expr.append(prim)
             for arg in reversed(prim.args):
                 stack.append((depth + 1, arg))

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -659,8 +659,8 @@ def cxOnePoint(ind1, ind2):
     types2 = defaultdict(list)
     if ind1.root.ret == __type__:
         # Not STGP optimization
-        types1[__type__] = range(1, len(ind1))
-        types2[__type__] = range(1, len(ind2))
+        types1[__type__] = list(range(1, len(ind1)))
+        types2[__type__] = list(range(1, len(ind2)))
         common_types = [__type__]
     else:
         for idx, node in enumerate(ind1[1:], 1):
@@ -1191,7 +1191,7 @@ def graph(expr):
        <http://networkx.lanl.gov/pygraphviz/>`_ as the nodes might be plotted
        out of order when using `NetworX <http://networkx.github.com/>`_.
     """
-    nodes = range(len(expr))
+    nodes = list(range(len(expr)))
     edges = list()
     labels = dict()
 

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -659,8 +659,8 @@ def cxOnePoint(ind1, ind2):
     types2 = defaultdict(list)
     if ind1.root.ret == __type__:
         # Not STGP optimization
-        types1[__type__] = xrange(1, len(ind1))
-        types2[__type__] = xrange(1, len(ind2))
+        types1[__type__] = range(1, len(ind1))
+        types2[__type__] = range(1, len(ind2))
         common_types = [__type__]
     else:
         for idx, node in enumerate(ind1[1:], 1):

--- a/deap/tests/test_init.py
+++ b/deap/tests/test_init.py
@@ -8,6 +8,6 @@ from deap import tools
 class LogbookTest(unittest.TestCase):
     def test_statistics_compile(self):
         l = 10
-        gen_idx = partial(random.sample, range(l), l)
+        gen_idx = partial(random.sample, list(range(l)), l)
         i = tools.initIterate(list, gen_idx)
         self.assertSetEqual(set(i), set(range(l)))

--- a/deap/tests/test_logbook.py
+++ b/deap/tests/test_logbook.py
@@ -7,7 +7,7 @@ class LogbookTest(unittest.TestCase):
 
     def setUp(self):
         self.logbook = tools.Logbook()
-        print
+        print()
 
     def test_multi_chapters(self):
         self.logbook.record(gen=0, evals=100, fitness={'obj 1' : {'avg' : 1.0, 'max' : 10},

--- a/deap/tools/_hypervolume/pyhv.py
+++ b/deap/tools/_hypervolume/pyhv.py
@@ -64,7 +64,7 @@ class _HyperVolume:
         """
 
         def weaklyDominates(point, other):
-            for i in xrange(len(point)):
+            for i in range(len(point)):
                 if point[i] > other[i]:
                     return False
             return True
@@ -152,7 +152,7 @@ class _HyperVolume:
                 hvol = qPrevDimIndex.volume[dimIndex] + qPrevDimIndex.area[dimIndex] * (qCargo[dimIndex] - qPrevDimIndex.cargo[dimIndex])
             else:
                 qArea[0] = 1
-                qArea[1:dimIndex+1] = [qArea[i] * -qCargo[i] for i in xrange(dimIndex)]
+                qArea[1:dimIndex+1] = [qArea[i] * -qCargo[i] for i in range(dimIndex)]
             q.volume[dimIndex] = hvol
             if q.ignore >= dimIndex:
                 qArea[dimIndex] = qPrevDimIndex.area[dimIndex]
@@ -184,7 +184,7 @@ class _HyperVolume:
         dimensions = len(self.referencePoint)
         nodeList = _MultiList(dimensions)
         nodes = [_MultiList.Node(dimensions, point) for point in front]
-        for i in xrange(dimensions):
+        for i in range(dimensions):
             self.sortByDimension(nodes, i)
             nodeList.extend(nodes, i)
         self.list = nodeList
@@ -239,7 +239,7 @@ class _MultiList:
 
     def __str__(self):
         strings = []
-        for i in xrange(self.numberLists):
+        for i in range(self.numberLists):
             currentList = []
             node = self.sentinel.next[i]
             while node != self.sentinel:
@@ -292,7 +292,7 @@ class _MultiList:
 
     def remove(self, node, index, bounds): 
         """Removes and returns 'node' from all lists in [0, 'index'[."""
-        for i in xrange(index): 
+        for i in range(index): 
             predecessor = node.prev[i]
             successor = node.next[i]
             predecessor.next[i] = successor
@@ -309,7 +309,7 @@ class _MultiList:
         nodes of the node that is reinserted are in the list.
 
         """
-        for i in xrange(index):
+        for i in range(index):
             node.prev[i].next[i] = node
             node.next[i].prev[i] = node
             if bounds[i] > node.cargo[i]:

--- a/deap/tools/crossover.py
+++ b/deap/tools/crossover.py
@@ -84,7 +84,7 @@ def cxUniform(ind1, ind2, indpb):
     :mod:`random` module.
     """
     size = min(len(ind1), len(ind2))
-    for i in xrange(size):
+    for i in range(size):
         if random.random() < indpb:
             ind1[i], ind2[i] = ind2[i], ind1[i]
 
@@ -115,7 +115,7 @@ def cxPartialyMatched(ind1, ind2):
     p1, p2 = [0] * size, [0] * size
 
     # Initialize the position of each indices in the individuals
-    for i in xrange(size):
+    for i in range(size):
         p1[ind1[i]] = i
         p2[ind2[i]] = i
     # Choose crossover points
@@ -127,7 +127,7 @@ def cxPartialyMatched(ind1, ind2):
         cxpoint1, cxpoint2 = cxpoint2, cxpoint1
 
     # Apply crossover between cx points
-    for i in xrange(cxpoint1, cxpoint2):
+    for i in range(cxpoint1, cxpoint2):
         # Keep track of the selected values
         temp1 = ind1[i]
         temp2 = ind2[i]
@@ -166,11 +166,11 @@ def cxUniformPartialyMatched(ind1, ind2, indpb):
     p1, p2 = [0] * size, [0] * size
 
     # Initialize the position of each indices in the individuals
-    for i in xrange(size):
+    for i in range(size):
         p1[ind1[i]] = i
         p2[ind2[i]] = i
 
-    for i in xrange(size):
+    for i in range(size):
         if random.random() < indpb:
             # Keep track of the selected values
             temp1 = ind1[i]
@@ -209,7 +209,7 @@ def cxOrdered(ind1, ind2):
        optimization and machine learning. Addison Wesley, 1989
     """
     size = min(len(ind1), len(ind2))
-    a, b = random.sample(xrange(size), 2)
+    a, b = random.sample(range(size), 2)
     if a > b:
         a, b = b, a
 
@@ -321,7 +321,7 @@ def cxSimulatedBinaryBounded(ind1, ind2, eta, low, up):
     elif len(up) < size:
         raise IndexError("up must be at least the size of the shorter individual: %d < %d" % (len(up), size))
 
-    for i, xl, xu in zip(xrange(size), low, up):
+    for i, xl, xu in zip(range(size), low, up):
         if random.random() <= 0.5:
             # This epsilon should probably be changed for 0 since
             # floating point arithmetic in Python is safer

--- a/deap/tools/crossover.py
+++ b/deap/tools/crossover.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import random
 import warnings
 

--- a/deap/tools/emo.py
+++ b/deap/tools/emo.py
@@ -625,13 +625,13 @@ def associate_to_niche(fitnesses, reference_points, best_point, intercepts):
 
 def niching(individuals, k, niches, distances, niche_counts):
     selected = []
-    available = numpy.ones(len(individuals), dtype=numpy.bool)
+    available = numpy.ones(len(individuals), dtype=bool)
     while len(selected) < k:
         # Maximum number of individuals (niches) to select in that round
         n = k - len(selected)
 
         # Find the available niches and the minimum niche count in them
-        available_niches = numpy.zeros(len(niche_counts), dtype=numpy.bool)
+        available_niches = numpy.zeros(len(niche_counts), dtype=bool)
         available_niches[numpy.unique(niches[available])] = True
         min_count = numpy.min(niche_counts[available_niches])
 

--- a/deap/tools/emo.py
+++ b/deap/tools/emo.py
@@ -129,7 +129,7 @@ def assignCrowdingDist(individuals):
 
     nobj = len(individuals[0].fitness.values)
 
-    for i in xrange(nobj):
+    for i in range(nobj):
         crowd.sort(key=lambda element: element[0][i])
         distances[crowd[0][1]] = float("inf")
         distances[crowd[-1][1]] = float("inf")
@@ -186,7 +186,7 @@ def selTournamentDCD(individuals, k):
     individuals_2 = random.sample(individuals, len(individuals))
 
     chosen = []
-    for i in xrange(0, k, 4):
+    for i in range(0, k, 4):
         chosen.append(tourn(individuals_1[i],   individuals_1[i+1]))
         chosen.append(tourn(individuals_1[i+2], individuals_1[i+3]))
         chosen.append(tourn(individuals_2[i],   individuals_2[i+1]))
@@ -620,7 +620,7 @@ def associate_to_niche(fitnesses, reference_points, best_point, intercepts):
 
     # Retrieve min distance niche index
     niches = numpy.argmin(distances, axis=1)
-    distances = distances[range(niches.shape[0]), niches]
+    distances = distances[list(range(niches.shape[0])), niches]
     return niches, distances
 
 
@@ -710,7 +710,7 @@ def selSPEA2(individuals, k):
     K = math.sqrt(N)
     strength_fits = [0] * N
     fits = [0] * N
-    dominating_inds = [list() for i in xrange(N)]
+    dominating_inds = [list() for i in range(N)]
 
     for i, ind_i in enumerate(individuals):
         for j, ind_j in enumerate(individuals[i+1:], i+1):
@@ -721,19 +721,19 @@ def selSPEA2(individuals, k):
                 strength_fits[j] += 1
                 dominating_inds[i].append(j)
 
-    for i in xrange(N):
+    for i in range(N):
         for j in dominating_inds[i]:
             fits[i] += strength_fits[j]
 
     # Choose all non-dominated individuals
-    chosen_indices = [i for i in xrange(N) if fits[i] < 1]
+    chosen_indices = [i for i in range(N) if fits[i] < 1]
 
     if len(chosen_indices) < k:     # The archive is too small
-        for i in xrange(N):
+        for i in range(N):
             distances = [0.0] * N
-            for j in xrange(i + 1, N):
+            for j in range(i + 1, N):
                 dist = 0.0
-                for l in xrange(L):
+                for l in range(L):
                     val = individuals[i].fitness.values[l] - \
                           individuals[j].fitness.values[l]
                     dist += val * val
@@ -742,7 +742,7 @@ def selSPEA2(individuals, k):
             density = 1.0 / (kth_dist + 2.0)
             fits[i] += density
 
-        next_indices = [(fits[i], i) for i in xrange(N)
+        next_indices = [(fits[i], i) for i in range(N)
                         if not i in chosen_indices]
         next_indices.sort()
         #print next_indices
@@ -750,12 +750,12 @@ def selSPEA2(individuals, k):
 
     elif len(chosen_indices) > k:   # The archive is too large
         N = len(chosen_indices)
-        distances = [[0.0] * N for i in xrange(N)]
-        sorted_indices = [[0] * N for i in xrange(N)]
-        for i in xrange(N):
-            for j in xrange(i + 1, N):
+        distances = [[0.0] * N for i in range(N)]
+        sorted_indices = [[0] * N for i in range(N)]
+        for i in range(N):
+            for j in range(i + 1, N):
                 dist = 0.0
-                for l in xrange(L):
+                for l in range(L):
                     val = individuals[chosen_indices[i]].fitness.values[l] - \
                           individuals[chosen_indices[j]].fitness.values[l]
                     dist += val * val
@@ -764,8 +764,8 @@ def selSPEA2(individuals, k):
             distances[i][i] = -1
 
         # Insert sort is faster than quick sort for short arrays
-        for i in xrange(N):
-            for j in xrange(1, N):
+        for i in range(N):
+            for j in range(1, N):
                 l = j
                 while l > 0 and distances[i][j] < distances[i][sorted_indices[i][l - 1]]:
                     sorted_indices[i][l] = sorted_indices[i][l - 1]
@@ -777,8 +777,8 @@ def selSPEA2(individuals, k):
         while size > k:
             # Search for minimal distance
             min_pos = 0
-            for i in xrange(1, N):
-                for j in xrange(1, size):
+            for i in range(1, N):
+                for j in range(1, size):
                     dist_i_sorted_j = distances[i][sorted_indices[i][j]]
                     dist_min_sorted_j = distances[min_pos][sorted_indices[min_pos][j]]
 
@@ -789,11 +789,11 @@ def selSPEA2(individuals, k):
                         break
 
             # Remove minimal distance from sorted_indices
-            for i in xrange(N):
+            for i in range(N):
                 distances[i][min_pos] = float("inf")
                 distances[min_pos][i] = float("inf")
 
-                for j in xrange(1, size - 1):
+                for j in range(1, size - 1):
                     if sorted_indices[i][j] == min_pos:
                         sorted_indices[i][j] = sorted_indices[i][j + 1]
                         sorted_indices[i][j + 1] = min_pos

--- a/deap/tools/emo.py
+++ b/deap/tools/emo.py
@@ -73,7 +73,7 @@ def sortNondominated(individuals, k, first_front_only=False):
     map_fit_ind = defaultdict(list)
     for ind in individuals:
         map_fit_ind[ind.fitness].append(ind)
-    fits = map_fit_ind.keys()
+    fits = list(map_fit_ind.keys())
 
     current_front = []
     next_front = []
@@ -249,7 +249,7 @@ def sortLogNondominated(individuals, k, first_front_only=False):
 
     #Launch the sorting algorithm
     obj = len(individuals[0].fitness.wvalues)-1
-    fitnesses = unique_fits.keys()
+    fitnesses = list(unique_fits.keys())
     front = dict.fromkeys(fitnesses, 0)
 
     # Sort the fitnesses lexicographically.

--- a/deap/tools/emo.py
+++ b/deap/tools/emo.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import bisect
 from collections import defaultdict, namedtuple
 from itertools import chain

--- a/deap/tools/indicator.py
+++ b/deap/tools/indicator.py
@@ -25,7 +25,7 @@ def hypervolume(front, **kargs):
         return hv.hypervolume(numpy.concatenate((wobj[:i], wobj[i+1:])), ref)
 
     # Parallelization note: Cannot pickle local function
-    contrib_values = map(contribution, range(len(front)))
+    contrib_values = list(map(contribution, list(range(len(front)))))
 
     # Select the maximum hypervolume value (correspond to the minimum difference)
     return numpy.argmax(contrib_values)

--- a/deap/tools/init.py
+++ b/deap/tools/init.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 def initRepeat(container, func, n):
     """Call the function *func* *n* times and return the results in a 
     container type `container`

--- a/deap/tools/init.py
+++ b/deap/tools/init.py
@@ -22,7 +22,7 @@ def initRepeat(container, func, n):
 
     See the :ref:`list-of-floats` and :ref:`population` tutorials for more examples.
     """
-    return container(func() for _ in xrange(n))
+    return container(func() for _ in range(n))
 
 def initIterate(container, generator):
     """Call the function *container* with an iterable as
@@ -72,7 +72,7 @@ def initCycle(container, seq_func, n=1):
 
     See the :ref:`funky` tutorial for an example.
     """
-    return container(func() for _ in xrange(n) for func in seq_func)
+    return container(func() for _ in range(n) for func in seq_func)
 
 __all__ = ['initRepeat', 'initIterate', 'initCycle']
 

--- a/deap/tools/migration.py
+++ b/deap/tools/migration.py
@@ -1,6 +1,3 @@
-from __future__ import division
-
-
 def migRing(populations, k, selection, replacement=None, migarray=None):
     """Perform a ring migration between the *populations*. The migration first
     select *k* emigrants from each population using the specified *selection*

--- a/deap/tools/migration.py
+++ b/deap/tools/migration.py
@@ -31,12 +31,12 @@ def migRing(populations, k, selection, replacement=None, migarray=None):
     """
     nbr_demes = len(populations)
     if migarray is None:
-        migarray = range(1, nbr_demes) + [0]
+        migarray = list(range(1, nbr_demes)) + [0]
 
-    immigrants = [[] for i in xrange(nbr_demes)]
-    emigrants = [[] for i in xrange(nbr_demes)]
+    immigrants = [[] for i in range(nbr_demes)]
+    emigrants = [[] for i in range(nbr_demes)]
 
-    for from_deme in xrange(nbr_demes):
+    for from_deme in range(nbr_demes):
         emigrants[from_deme].extend(selection(populations[from_deme], k))
         if replacement is None:
             # If no replacement strategy is selected, replace those who migrate

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import math
 import random
 

--- a/deap/tools/mutation.py
+++ b/deap/tools/mutation.py
@@ -41,7 +41,7 @@ def mutGaussian(individual, mu, sigma, indpb):
     elif len(sigma) < size:
         raise IndexError("sigma must be at least the size of individual: %d < %d" % (len(sigma), size))
 
-    for i, m, s in zip(xrange(size), mu, sigma):
+    for i, m, s in zip(range(size), mu, sigma):
         if random.random() < indpb:
             individual[i] += random.gauss(m, s)
 
@@ -72,7 +72,7 @@ def mutPolynomialBounded(individual, eta, low, up, indpb):
     elif len(up) < size:
         raise IndexError("up must be at least the size of individual: %d < %d" % (len(up), size))
 
-    for i, xl, xu in zip(xrange(size), low, up):
+    for i, xl, xu in zip(range(size), low, up):
         if random.random() <= indpb:
             x = individual[i]
             delta_1 = (x - xl) / (xu - xl)
@@ -110,7 +110,7 @@ def mutShuffleIndexes(individual, indpb):
     functions from the python base :mod:`random` module.
     """
     size = len(individual)
-    for i in xrange(size):
+    for i in range(size):
         if random.random() < indpb:
             swap_indx = random.randint(0, size - 2)
             if swap_indx >= i:
@@ -135,7 +135,7 @@ def mutFlipBit(individual, indpb):
     This function uses the :func:`~random.random` function from the python base
     :mod:`random` module.
     """
-    for i in xrange(len(individual)):
+    for i in range(len(individual)):
         if random.random() < indpb:
             individual[i] = type(individual[i])(not individual[i])
 
@@ -166,7 +166,7 @@ def mutUniformInt(individual, low, up, indpb):
     elif len(up) < size:
         raise IndexError("up must be at least the size of individual: %d < %d" % (len(up), size))
 
-    for i, xl, xu in zip(xrange(size), low, up):
+    for i, xl, xu in zip(range(size), low, up):
         if random.random() < indpb:
             individual[i] = random.randint(xl, xu)
 
@@ -207,7 +207,7 @@ def mutESLogNormal(individual, c, indpb):
     n = random.gauss(0, 1)
     t0_n = t0 * n
 
-    for indx in xrange(size):
+    for indx in range(size):
         if random.random() < indpb:
             individual.strategy[indx] *= math.exp(t0_n + t * random.gauss(0, 1))
             individual[indx] += individual.strategy[indx] * random.gauss(0, 1)

--- a/deap/tools/selection.py
+++ b/deap/tools/selection.py
@@ -229,13 +229,10 @@ def selLexicase(individuals, k):
         random.shuffle(cases)
 
         while len(cases) > 0 and len(candidates) > 1:
-            f = min
-            if fit_weights[cases[0]] > 0:
-                f = max
+            f = max if fit_weights[cases[0]] > 0 else min
+            best_val_for_case = f(x.fitness.values[cases[0]] for x in candidates)
 
-            best_val_for_case = f(map(lambda x: x.fitness.values[cases[0]], candidates))
-
-            candidates = list(filter(lambda x: x.fitness.values[cases[0]] == best_val_for_case, candidates))
+            candidates = [x for x in candidates if x.fitness.values[cases[0]] == best_val_for_case]
             cases.pop(0)
 
         selected_individuals.append(random.choice(candidates))
@@ -265,13 +262,13 @@ def selEpsilonLexicase(individuals, k, epsilon):
 
         while len(cases) > 0 and len(candidates) > 1:
             if fit_weights[cases[0]] > 0:
-                best_val_for_case = max(map(lambda x: x.fitness.values[cases[0]], candidates))
+                best_val_for_case = max(x.fitness.values[cases[0]] for x in candidates)
                 min_val_to_survive_case = best_val_for_case - epsilon
-                candidates = list(filter(lambda x: x.fitness.values[cases[0]] >= min_val_to_survive_case, candidates))
+                candidates = [x for x in candidates if x.fitness.values[cases[0]] >= min_val_to_survive_case]
             else :
-                best_val_for_case = min(map(lambda x: x.fitness.values[cases[0]], candidates))
+                best_val_for_case = min(x.fitness.values[cases[0]] for x in candidates)
                 max_val_to_survive_case = best_val_for_case + epsilon
-                candidates = list(filter(lambda x: x.fitness.values[cases[0]] <= max_val_to_survive_case, candidates))
+                candidates = [x for x in candidates if x.fitness.values[cases[0]] <= max_val_to_survive_case]
 
             cases.pop(0)
 
@@ -306,11 +303,11 @@ def selAutomaticEpsilonLexicase(individuals, k):
             if fit_weights[cases[0]] > 0:
                 best_val_for_case = max(errors_for_this_case)
                 min_val_to_survive = best_val_for_case - median_absolute_deviation
-                candidates = list(filter(lambda x: x.fitness.values[cases[0]] >= min_val_to_survive, candidates))
+                candidates = [x for x in candidates if x.fitness.values[cases[0]] >= min_val_to_survive]
             else :
                 best_val_for_case = min(errors_for_this_case)
                 max_val_to_survive = best_val_for_case + median_absolute_deviation
-                candidates = list(filter(lambda x: x.fitness.values[cases[0]] <= max_val_to_survive, candidates))
+                candidates = [x for x in candidates if x.fitness.values[cases[0]] <= max_val_to_survive]
 
             cases.pop(0)
 

--- a/deap/tools/selection.py
+++ b/deap/tools/selection.py
@@ -21,7 +21,7 @@ def selRandom(individuals, k):
     This function uses the :func:`~random.choice` function from the
     python base :mod:`random` module.
     """
-    return [random.choice(individuals) for i in xrange(k)]
+    return [random.choice(individuals) for i in range(k)]
 
 
 def selBest(individuals, k, fit_attr="fitness"):
@@ -63,7 +63,7 @@ def selTournament(individuals, k, tournsize, fit_attr="fitness"):
     :mod:`random` module.
     """
     chosen = []
-    for i in xrange(k):
+    for i in range(k):
         aspirants = selRandom(individuals, tournsize)
         chosen.append(max(aspirants, key=attrgetter(fit_attr)))
     return chosen
@@ -90,7 +90,7 @@ def selRoulette(individuals, k, fit_attr="fitness"):
     s_inds = sorted(individuals, key=attrgetter(fit_attr), reverse=True)
     sum_fits = sum(getattr(ind, fit_attr).values[0] for ind in individuals)
     chosen = []
-    for i in xrange(k):
+    for i in range(k):
         u = random.random() * sum_fits
         sum_ = 0
         for ind in s_inds:
@@ -147,7 +147,7 @@ def selDoubleTournament(individuals, k, fitness_size, parsimony_size, fitness_fi
 
     def _sizeTournament(individuals, k, select):
         chosen = []
-        for i in xrange(k):
+        for i in range(k):
             # Select two individuals from the population
             # The first individual has to be the shortest
             prob = parsimony_size / 2.
@@ -167,7 +167,7 @@ def selDoubleTournament(individuals, k, fitness_size, parsimony_size, fitness_fi
 
     def _fitTournament(individuals, k, select):
         chosen = []
-        for i in xrange(k):
+        for i in range(k):
             aspirants = select(individuals, k=fitness_size)
             chosen.append(max(aspirants, key=attrgetter(fit_attr)))
         return chosen
@@ -198,7 +198,7 @@ def selStochasticUniversalSampling(individuals, k, fit_attr="fitness"):
 
     distance = sum_fits / float(k)
     start = random.uniform(0, distance)
-    points = [start + i*distance for i in xrange(k)]
+    points = [start + i*distance for i in range(k)]
 
     chosen = []
     for p in points:

--- a/deap/tools/selection.py
+++ b/deap/tools/selection.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import random
 import numpy as np
 

--- a/deap/tools/support.py
+++ b/deap/tools/support.py
@@ -200,7 +200,7 @@ class Statistics(object):
         values = tuple(self.key(elem) for elem in data)
 
         entry = dict()
-        for key, func in self.functions.iteritems():
+        for key, func in self.functions.items():
             entry[key] = func(values)
         return entry
 

--- a/deap/tools/support.py
+++ b/deap/tools/support.py
@@ -335,7 +335,7 @@ class Logbook(list):
         key part of the pair. Chapters are also Logbook.
         """
         apply_to_all = {k: v for k, v in infos.items() if not isinstance(v, dict)}
-        for key, value in infos.items():
+        for key, value in list(infos.items()):
             if isinstance(value, dict):
                 chapter_infos = value.copy()
                 chapter_infos.update(apply_to_all)
@@ -426,7 +426,7 @@ class Logbook(list):
         if not columns:
             columns = sorted(self[0].keys()) + sorted(self.chapters.keys())
         if not self.columns_len or len(self.columns_len) != len(columns):
-            self.columns_len = map(len, columns)
+            self.columns_len = [len(c) for c in columns]
 
         chapters_txt = {}
         offsets = defaultdict(int)

--- a/deap/tools/support.py
+++ b/deap/tools/support.py
@@ -1,9 +1,4 @@
-from __future__ import division
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from bisect import bisect_right
 from collections import defaultdict

--- a/deap/tools/support.py
+++ b/deap/tools/support.py
@@ -459,16 +459,16 @@ class Logbook(list):
             nlines = 1
             if len(self.chapters) > 0:
                 nlines += max(map(len, chapters_txt.values())) - len(self) + 1
-            header = [[] for i in xrange(nlines)]
+            header = [[] for i in range(nlines)]
             for j, name in enumerate(columns):
                 if name in chapters_txt:
                     length = max(len(line.expandtabs()) for line in chapters_txt[name])
                     blanks = nlines - 2 - offsets[name]
-                    for i in xrange(blanks):
+                    for i in range(blanks):
                         header[i].append(" " * length)
                     header[blanks].append(name.center(length))
                     header[blanks+1].append("-" * length)
-                    for i in xrange(offsets[name]):
+                    for i in range(offsets[name]):
                         header[blanks+2+i].append(chapters_txt[name][i])
                 else:
                     length = max(len(line[j].expandtabs()) for line in str_matrix)

--- a/doc/code/tutorials/part_2/2_2_5_particle.py
+++ b/doc/code/tutorials/part_2/2_2_5_particle.py
@@ -10,8 +10,8 @@ creator.create("Particle", list, fitness=creator.FitnessMax, speed=None,
                smin=None, smax=None, best=None)
 
 def initParticle(pcls, size, pmin, pmax, smin, smax):
-    part = pcls(random.uniform(pmin, pmax) for _ in xrange(size))
-    part.speed = [random.uniform(smin, smax) for _ in xrange(size)]
+    part = pcls(random.uniform(pmin, pmax) for _ in range(size))
+    part.speed = [random.uniform(smin, smax) for _ in range(size)]
     part.smin = smin
     part.smax = smax
     return part

--- a/doc/code/tutorials/part_2/2_3_3_swarm.py
+++ b/doc/code/tutorials/part_2/2_3_3_swarm.py
@@ -11,8 +11,8 @@ creator.create("Particle", list, fitness=creator.FitnessMax, speed=None,
 creator.create("Swarm", list, gbest=None, gbestfit=creator.FitnessMax)
 
 def initParticle(pcls, size, pmin, pmax, smin, smax):
-    part = pcls(random.uniform(pmin, pmax) for _ in xrange(size))
-    part.speed = [random.uniform(smin, smax) for _ in xrange(size)]
+    part = pcls(random.uniform(pmin, pmax) for _ in range(size))
+    part.speed = [random.uniform(smin, smax) for _ in range(size)]
     part.smin = smin
     part.smax = smax
     return part

--- a/doc/code/tutorials/part_3/3_6_2_tool_decoration.py
+++ b/doc/code/tutorials/part_3/3_6_2_tool_decoration.py
@@ -10,7 +10,7 @@ def checkBounds(min, max):
         def wrapper(*args, **kargs):
             offspring = func(*args, **kargs)
             for child in offspring:
-                for i in xrange(len(child)):
+                for i in range(len(child)):
                     if child[i] > max:
                         child[i] = max
                     elif child[i] < min:

--- a/doc/code/tutorials/part_3/3_next_step.py
+++ b/doc/code/tutorials/part_3/3_next_step.py
@@ -17,8 +17,8 @@ toolbox.register("individual", tools.initRepeat, creator.Individual,
 
 ind1 = toolbox.individual()
 
-print ind1               # [0.86..., 0.27..., 0.70..., 0.03..., 0.87...]
-print ind1.fitness.valid # False
+print(ind1)               # [0.86..., 0.27..., 0.70..., 0.03..., 0.87...]
+print(ind1.fitness.valid) # False
 
 ## 3.2 Evaluation
 def evaluate(individual):
@@ -28,16 +28,16 @@ def evaluate(individual):
     return a, 1. / b
 
 ind1.fitness.values = evaluate(ind1)
-print ind1.fitness.valid    # True
-print ind1.fitness          # (2.73, 0.2)
+print(ind1.fitness.valid)    # True
+print(ind1.fitness)          # (2.73, 0.2)
 
 ## 3.3 Mutation
 mutant = toolbox.clone(ind1)
 ind2, = tools.mutGaussian(mutant, mu=0.0, sigma=0.2, indpb=0.2)
 del mutant.fitness.values
 
-print ind2 is mutant    # True
-print mutant is ind1    # False
+print(ind2 is mutant)    # True
+print(mutant is ind1)    # False
 
 ## 3.4 Crossover
 child1, child2 = [toolbox.clone(ind) for ind in (ind1, ind2)]
@@ -47,7 +47,7 @@ del child2.fitness.values
 
 ## 3.5 Selection
 selected = tools.selBest([child1, child2], 2)
-print child1 in selected	# True
+print(child1 in selected)	# True
 
 ## 3.5 Note
 LAMBDA = 10

--- a/doc/code/tutorials/part_4/4_4_Using_Cpp_NSGA.py
+++ b/doc/code/tutorials/part_4/4_4_Using_Cpp_NSGA.py
@@ -92,7 +92,7 @@ def main():
 
     # Begin the evolution
     for g in xrange(NGEN):
-        print "-- Generation %i --" % g
+        print("-- Generation %i --" % g)
         offspring = [toolbox.clone(ind) for ind in population]
 
         # Apply crossover and mutation
@@ -121,21 +121,21 @@ def main():
         for ind, fit in zip(invalid_ind, fitnesses):
             ind.fitness.values = fit
 
-        print "  Evaluated %i individuals" % len(invalid_ind)
+        print("  Evaluated %i individuals" % len(invalid_ind))
 
         population = toolbox.select(population+offspring, len(offspring))
         hof.update(population)
         stats.update(population)
 
-        print "  Min %s" % stats.Min[0][-1][0]
-        print "  Max %s" % stats.Max[0][-1][0]
-        print "  Avg %s" % stats.Avg[0][-1][0]
-        print "  Std %s" % stats.Std[0][-1][0]
+        print("  Min %s" % stats.Min[0][-1][0])
+        print("  Max %s" % stats.Max[0][-1][0])
+        print("  Avg %s" % stats.Avg[0][-1][0])
+        print("  Std %s" % stats.Std[0][-1][0])
 
     best_network = sn.SortingNetwork(INPUTS, hof[0])
-    print best_network
-    print best_network.draw()
-    print "%i errors, length %i, depth %i" % hof[0].fitness.values
+    print(best_network)
+    print(best_network.draw())
+    print("%i errors, length %i, depth %i" % hof[0].fitness.values)
 
     return population, stats, hof
 

--- a/doc/code/tutorials/part_4/4_4_Using_Cpp_NSGA.py
+++ b/doc/code/tutorials/part_4/4_4_Using_Cpp_NSGA.py
@@ -34,7 +34,7 @@ def genWire(dimension):
 
 def genNetwork(dimension, min_size, max_size):
     size = random.randint(min_size, max_size)
-    return [genWire(dimension) for i in xrange(size)]
+    return [genWire(dimension) for i in range(size)]
 
 def mutWire(individual, dimension, indpb):
     for index, elem in enumerate(individual):
@@ -91,7 +91,7 @@ def main():
     stats.update(population)
 
     # Begin the evolution
-    for g in xrange(NGEN):
+    for g in range(NGEN):
         print("-- Generation %i --" % g)
         offspring = [toolbox.clone(ind) for ind in population]
 

--- a/doc/code/tutorials/part_4/4_5_home_made_eval_func.py
+++ b/doc/code/tutorials/part_4/4_5_home_made_eval_func.py
@@ -40,7 +40,7 @@ def genWire(dimension):
 
 def genNetwork(dimension, min_size, max_size):
     size = random.randint(min_size, max_size)
-    return [genWire(dimension) for i in xrange(size)]
+    return [genWire(dimension) for i in range(size)]
 
 def mutWire(individual, dimension, indpb):
     for index, elem in enumerate(individual):
@@ -97,7 +97,7 @@ def main():
     stats.update(population)
 
     # Begin the evolution
-    for g in xrange(NGEN):
+    for g in range(NGEN):
         t1 = time.time()
         print("-- Generation %i --" % g)
         offspring = [toolbox.clone(ind) for ind in population]

--- a/doc/code/tutorials/part_4/4_5_home_made_eval_func.py
+++ b/doc/code/tutorials/part_4/4_5_home_made_eval_func.py
@@ -99,7 +99,7 @@ def main():
     # Begin the evolution
     for g in xrange(NGEN):
         t1 = time.time()
-        print "-- Generation %i --" % g
+        print("-- Generation %i --" % g)
         offspring = [toolbox.clone(ind) for ind in population]
         t2 = time.time()
         # Apply crossover and mutation
@@ -128,14 +128,14 @@ def main():
         for ind, fit in zip(invalid_ind, fitnesses):
             ind.fitness.values = fit
 
-        print "  Evaluated %i individuals" % len(invalid_ind)
+        print("  Evaluated %i individuals" % len(invalid_ind))
         t5 = time.time()
         population = toolbox.select(population+offspring, len(offspring))
         t6 = time.time()
         #hof.update(population)
         stats.update(population)
         t7 = time.time()
-        print stats
+        print(stats)
 
         print("Times :")
         print("Clone : " + str(t2-t1) + " (" + str((t2-t1)/(t7-t1)) +"%)")
@@ -148,9 +148,9 @@ def main():
 
 
     best_network = sn.SortingNetwork(INPUTS, hof[0])
-    print best_network
-    print best_network.draw()
-    print "%i errors, length %i, depth %i" % hof[0].fitness.values
+    print(best_network)
+    print(best_network.draw())
+    print("%i errors, length %i, depth %i" % hof[0].fitness.values)
 
     return population, stats, hof
 

--- a/doc/code/tutorials/part_4/sortingnetwork.py
+++ b/doc/code/tutorials/part_4/sortingnetwork.py
@@ -55,7 +55,7 @@ class SortingNetwork(list):
             self.append({wire1: wire2})
             return
 
-        for wires in last_level.iteritems():
+        for wires in last_level.items():
             if wires[1] >= wire1 and wires[0] <= wire2:
                 self.append({wire1: wire2})
                 return
@@ -65,7 +65,7 @@ class SortingNetwork(list):
     def sort(self, values):
         """Sort the values in-place based on the connectors in the network."""
         for level in self:
-            for wire1, wire2 in level.iteritems():
+            for wire1, wire2 in level.items():
                 if values[wire1] > values[wire2]:
                     values[wire1], values[wire2] = values[wire2], values[wire1]
 
@@ -99,7 +99,7 @@ class SortingNetwork(list):
             str_wires[i][1] = " o"
 
         for index, level in enumerate(self):
-            for wire1, wire2 in level.iteritems():
+            for wire1, wire2 in level.items():
                 str_wires[wire1][(index+1)*6] = "x"
                 str_wires[wire2][(index+1)*6] = "x"
                 for i in range(wire1, wire2):

--- a/doc/code/tutorials/part_4/sortingnetwork.py
+++ b/doc/code/tutorials/part_4/sortingnetwork.py
@@ -92,7 +92,7 @@ class SortingNetwork(list):
         str_wires[0][1] = " o"
         str_spaces = []
 
-        for i in xrange(1, self.dimension):
+        for i in range(1, self.dimension):
             str_wires.append(["-"]*7 * self.depth)
             str_spaces.append([" "]*7 * self.depth)
             str_wires[i][0] = str(i)
@@ -102,9 +102,9 @@ class SortingNetwork(list):
             for wire1, wire2 in level.iteritems():
                 str_wires[wire1][(index+1)*6] = "x"
                 str_wires[wire2][(index+1)*6] = "x"
-                for i in xrange(wire1, wire2):
+                for i in range(wire1, wire2):
                     str_spaces[i][(index+1)*6+1] = "|"
-                for i in xrange(wire1+1, wire2):
+                for i in range(wire1+1, wire2):
                     str_wires[i][(index+1)*6] = "|"
 
         network_draw = "".join(str_wires[0])

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ def run_setup(build_ext):
          ext_modules=extra_modules,
          cmdclass={"build_ext": ve_build_ext},
          install_requires=['numpy'],
-         use_2to3=True
     )
 
 try:


### PR DESCRIPTION
Python3.11 dropped support for 2to3, so its use in setup.py creates problems during installation.
This patchset rewrites the code (using 2to3 as the base) to python3 and does some minor
cleanups on the way.

All warnings are eliminated.