### PR TITLE
README `setuptools` version for `2to3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ DEAP build status is available on Travis-CI https://travis-ci.org/DEAP/deap.
 ## Requirements
 The most basic features of DEAP requires Python2.6. In order to combine the toolbox and the multiprocessing module Python2.7 is needed for its support to pickle partial functions. CMA-ES requires Numpy, and we recommend matplotlib for visualization of results as it is fully compatible with DEAP's API.
 
-Since version 0.8, DEAP is compatible out of the box with Python 3. The installation procedure automatically translates the source to Python 3 with 2to3.
+Since version 0.8, DEAP is compatible out of the box with Python 3. The installation procedure automatically translates the source to Python 3 with 2to3, however this requires having `setuptools<=5.8`. It is recommended to use `pip install setuptools==57.5.0` to address this issue.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ DEAP build status is available on Travis-CI https://travis-ci.org/DEAP/deap.
 ## Requirements
 The most basic features of DEAP requires Python2.6. In order to combine the toolbox and the multiprocessing module Python2.7 is needed for its support to pickle partial functions. CMA-ES requires Numpy, and we recommend matplotlib for visualization of results as it is fully compatible with DEAP's API.
 
-Since version 0.8, DEAP is compatible out of the box with Python 3. The installation procedure automatically translates the source to Python 3 with 2to3, however this requires having `setuptools<=5.8`. It is recommended to use `pip install setuptools==57.5.0` to address this issue.
+Since version 0.8, DEAP is compatible out of the box with Python 3. The installation procedure automatically translates the source to Python 3 with 2to3, however this requires having `setuptools<=58`. It is recommended to use `pip install setuptools==57.5.0` to address this issue.
 
 ## Example
 


### PR DESCRIPTION
Add a note to the readme's requirement section to discuss using `setuptools<=58` to accommodate `2to3`.