### PR TITLE
Fix a Python 3 compatibility issue with ADFs

### DIFF
--- a/deap/gp.py
+++ b/deap/gp.py
@@ -506,7 +506,7 @@ def compileADF(expr, psets):
     """
     adfdict = {}
     func = None
-    for pset, subexpr in reversed(zip(psets, expr)):
+    for pset, subexpr in list(zip(psets, expr))[::-1]:
         pset.context.update(adfdict)
         func = compile(subexpr, pset)
         adfdict.update({pset.name: func})


### PR DESCRIPTION
`zip(...)` no longer creates a list in recent Python versions, so explicitly create one and use slicing syntax to reverse instead.