### PR TITLE
Switch read to use binary mode in Checkpoint example

### DIFF
--- a/doc/tutorials/advanced/checkpoint.rst
+++ b/doc/tutorials/advanced/checkpoint.rst
@@ -23,7 +23,7 @@ argument containing the path of the checkpoint file to restore. ::
     def main(checkpoint=None):
         if checkpoint:
             # A file name has been given, then load the data from the file
-            with open(checkpoint, "r") as cp_file:
+            with open(checkpoint, "rb") as cp_file:
                 cp = pickle.load(cp_file)
             population = cp["population"]
             start_gen = cp["generation"]


### PR DESCRIPTION
The docs shows an example of saving in binary mode but then opening not using python's binary mode. This causes an error to be thrown when opening the file.

Fixes #489, Fixes #657 

The example below shows using pickle to save a dictionary in `wb` mode and load it in both `rb` and `r` mode. The `rb` move value will load correctly whereas the `r` mode load will not.
```python
import pickle

data = dict(firstValue=1, secondValue = "Example value")

# save using 'wb' mode
with open("docsIssue.pkl", "wb") as file:
            pickle.dump(data, file)

# will load the data correctly using rb mode
with open("docsIssue.pkl", "rb") as file:
    loadedDatarb = pickle.load(file)

print("loadedData using rb mode", loadedDatarb)

# will throw an error when not using binary mode
with open("docsIssue.pkl", "r") as file:
    loadedDatar = pickle.load(file)

print("loadedData using r mode", loadedDatar)
```