### PR TITLE
Update compileADF in gp.py to work with python3

### DIFF
--- a/deap/gp.py
+++ b/deap/gp.py
@@ -506,7 +506,7 @@ def compileADF(expr, psets):
     """
     adfdict = {}
     func = None
-    for pset, subexpr in reversed(zip(psets, expr)):
+    for pset, subexpr in reversed(list(zip(psets, expr))):
         pset.context.update(adfdict)
         func = compile(subexpr, pset)
         adfdict.update({pset.name: func})


### PR DESCRIPTION
Should close #671, though further testing for 2->3 changes might be suggested throughout DEAP
