### PR TITLE
Include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include *.md
 recursive-include deap *.cpp *.c *.hpp *.h
 recursive-include examples *.py *.csv *.json *.txt *.cpp *.hpp *.h
 recursive-include doc *
+recursive-include tests *
 prune doc/_build
 global-exclude .DS_Store
 global-exclude *.pyc


### PR DESCRIPTION
Congratulations on `1.4.0`!

This restores the `tests` to the `sdist`, which helps for downstreams such as https://github.com/conda-forge/deap-feedstock/pull/22.

A near term helpful fix so we can get 1.4.0 out would be to create https://github.com/DEAP/deap/releases/tag/1.4.0 so that the GitHub tarball at least has a predictable URL (and _sorta_ reproducible SHA256) until a release which contains the `tests` is made.