### PR TITLE
Fix for cxOnePointLeafBiased and python 3.11

### DIFF
--- a/deap/gp.py
+++ b/deap/gp.py
@@ -744,7 +744,7 @@ def cxOnePointLeafBiased(ind1, ind2, termpb):
 
     if len(common_types) > 0:
         # Set does not support indexing
-        type_ = random.sample(common_types, 1)[0]
+        type_ = random.sample(list(common_types, 1))[0]
         index1 = random.choice(types1[type_])
         index2 = random.choice(types2[type_])
 

--- a/deap/gp.py
+++ b/deap/gp.py
@@ -744,7 +744,7 @@ def cxOnePointLeafBiased(ind1, ind2, termpb):
 
     if len(common_types) > 0:
         # Set does not support indexing
-        type_ = random.sample(list(common_types, 1))[0]
+        type_ = random.sample(list(common_types), 1)[0]
         index1 = random.choice(types1[type_])
         index2 = random.choice(types2[type_])
 


### PR DESCRIPTION
Changes in python's random module require a minor change for cxOnePointLeafBiased.