### PR TITLE
fix IndexError: The gp.generate function tried to add a primitive of …

### DIFF
--- a/deap/gp.py
+++ b/deap/gp.py
@@ -631,7 +631,7 @@ def generate(pset, min_, max_, condition, type_=None):
     stack = [(0, type_)]
     while len(stack) != 0:
         depth, type_ = stack.pop()
-        if condition(height, depth):
+        if condition(height, depth) or len(pset.primitives[type_]) == 0:
             try:
                 term = random.choice(pset.terminals[type_])
             except IndexError:


### PR DESCRIPTION
IndexError: The gp.generate function tried to add a primitive of type '<class 'int'>', but there is none available.

fix #579 