### PR TITLE
Fix quote that break documentation visualization

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,7 +13,7 @@ and many features to build your own evolutions.
 
 .. sidebar:: Getting Help
     
-    Having trouble? We’d like to help!
+    Having trouble? We'd like to help!
 
     * Search for information in the archives of the `deap-users mailing list 
       <https://groups.google.com/forum/?fromgroups#!forum/deap-users>`_,


### PR DESCRIPTION
The quote used currently is breaking the visualization of the documentation.

![image](https://github.com/DEAP/deap/assets/7605307/0ea2593a-de5b-42c7-9e49-50bee2165875)

