### PR TITLE
Fix no terminal/primitives available issue

### DIFF
--- a/deap/gp.py
+++ b/deap/gp.py
@@ -631,7 +631,7 @@ def generate(pset, min_, max_, condition, type_=None):
     stack = [(0, type_)]
     while len(stack) != 0:
         depth, type_ = stack.pop()
-        if condition(height, depth):
+        if len(pset.terminals[type_]) != 0 and (True if len(pset.primitives[type_])==0 else condition(height, depth)):
             try:
                 term = random.choice(pset.terminals[type_])
             except IndexError:


### PR DESCRIPTION
Currently a `IndexError: list index out of range` will occur if there are no terminals or primitives, and although both being unavailable would be a legitimate error, there is no reason not to avoid the condition altogether in cases where one or the other is not available.

Fixes #219