### PR TITLE
Add helpful hints to multiprocess doc for avoiding mem leaks

### DIFF
--- a/doc/tutorials/basic/part4.rst
+++ b/doc/tutorials/basic/part4.rst
@@ -53,6 +53,12 @@ toolbox.
     import multiprocessing
 
     pool = multiprocessing.Pool()
+    # OR use the following to ensure releasing memory after each evaluate call
+    #  This helps in situation where an external library holds memory, ex: Tensorflow
+    #  when maxtaskperchild is set to 1, a new process is forked after each completed task
+    #  https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing.pool
+    # pool = multiprocessing.Pool(maxtasksperchild=1)
+
     toolbox.register("map", pool.map)
 
     # Continue on with the evolutionary algorithm


### PR DESCRIPTION
Recently ran into an issue with multiprocessing and memleaks. The system chewed up 32GB or ram and then some 2 GB of swap, with 2 gens left to finish, after some 4 hours of darwin chugging silicon oil.

I've noticed a few open issues complaining about mem leak while using multiprocessing.

The issue is noticed when libs like tensorflow are used, that have a mind of their own. Clearing up the session/explicit gc/del model or anything besides terminating the process doesn't help.

I think the addition of code sample in the doc will help many avoid this. And avoid issues being created for mem leak.