### PR TITLE
Changes in python's random module require a minor change for `cxOnePointLeafBiased`.

### DIFF
--- a/deap/gp.py
+++ b/deap/gp.py
@@ -744,7 +744,7 @@ def cxOnePointLeafBiased(ind1, ind2, termpb):
 
     if len(common_types) > 0:
         # Set does not support indexing
-        type_ = random.sample(common_types, 1)[0]
+        type_ = random.choice(list(common_types))
         index1 = random.choice(types1[type_])
         index2 = random.choice(types2[type_])
 


### PR DESCRIPTION
#733 already exists which is a fix for #732 but the PR is stale as code review changes were not addressed for 6+ months. This is an attempt to fix that. We were experimenting with `deap` to understand `gp` which is when we discovered this bug and saw it was already an issue. However before the fix, issue was closed.

This PR fixes #732 

Please review @cyrilpic @professor @bollwyvl @jmmcd @keszybz @fmder 
I didn't know exactly who to tag. That's y I tagged everyone.